### PR TITLE
Phase 3: new examples + docker-compose for infra dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,63 +4,148 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 
 ## Examples
 
-| Directory | Description | Topics |
-|-----------|-------------|--------|
-| [benchmark](examples/benchmark/) | Benchmarks with `testing.B` | testing, performance |
-| [channels](examples/channels/) | Goroutine communication with channels | concurrency |
-| [concurrency/worker-pool](examples/concurrency/worker-pool/) | Fixed pool of goroutines consuming a shared job channel | concurrency |
-| [concurrency/scatter-gather](examples/concurrency/scatter-gather/) | Fan-out: one goroutine per task, collect all results | concurrency |
-| [concurrency/fan-out-timeout](examples/concurrency/fan-out-timeout/) | Fan-out with per-worker deadline via `time.After` | concurrency |
-| [config](examples/config/) | Reading JSON configuration with `encoding/json` | stdlib |
-| [datetime-parse](examples/datetime-parse/) | Parsing dates in multiple formats | libraries |
-| [dynamodb](examples/dynamodb/) | DynamoDB CRUD with AWS SDK v1 | AWS, databases |
-| [flags](examples/flags/) | Command-line flags with the `flag` package | stdlib, CLI |
-| [gin](examples/gin/) | Minimal HTTP API with Gin | HTTP, frameworks |
-| [inject](examples/inject/) | Dependency injection via constructor functions | DI, patterns |
-| [lambda](examples/lambda/) | AWS Lambda function in Go | AWS, serverless |
-| [metric](examples/metric/) | Sending metrics to Datadog via StatsD | observability |
-| [mysql](examples/mysql/) | MySQL connection and queries | databases |
-| [oop](examples/oop/) | Methods, interfaces and polymorphism in Go | patterns |
-| [oop/composition](examples/oop/composition/) | Struct embedding as Go's alternative to inheritance | patterns |
-| [pool](examples/pool/) | Worker pool with per-task error tracking | concurrency, patterns |
-| [profiling](examples/profiling/) | CPU/memory profiling with `pkg/profile` | performance |
-| [protobuf](examples/protobuf/) | Binary serialization with Protocol Buffers | serialization |
-| [recover](examples/recover/) | Panic handling with `recover` | error handling |
-| [redis](examples/redis/) | Task queue with Redis and Gin (go-redis v9) | Redis, HTTP |
-| [reflection-bench](examples/reflection-bench/) | Benchmarking reflection vs direct types | performance, reflection |
-| [serialization](examples/serialization/) | Flexible JSON: field that is either an object or array | serialization |
-| [share-memory-by-communicating](examples/share-memory-by-communicating/) | HTTP URL poller using channels — from the Go blog | concurrency |
-| [testing](examples/testing/) | Basic unit tests | testing |
-| [typecast](examples/typecast/) | Benchmarks: type switch vs type assertion vs interface | performance |
-| [wire](examples/wire/) | Compile-time dependency injection with Wire | DI, code generation |
+### Concurrency
+
+| Directory | Description |
+|-----------|-------------|
+| [channels](examples/channels/) | Goroutine communication with channels |
+| [concurrency/worker-pool](examples/concurrency/worker-pool/) | Fixed pool consuming a shared job channel |
+| [concurrency/scatter-gather](examples/concurrency/scatter-gather/) | One goroutine per task, collect all results |
+| [concurrency/fan-out-timeout](examples/concurrency/fan-out-timeout/) | Per-worker deadline with `time.After` |
+| [errgroup](examples/errgroup/) | `errgroup.WithContext` vs manual WaitGroup; `SetLimit` for bounded concurrency |
+| [pool](examples/pool/) | Generic worker pool with per-task error tracking |
+| [share-memory-by-communicating](examples/share-memory-by-communicating/) | URL poller via channels — from the Go blog |
+| [sync-primitives](examples/sync-primitives/) | `sync.Once`, `sync.Map`, and `atomic` operations |
+
+### Error Handling
+
+| Directory | Description |
+|-----------|-------------|
+| [errors](examples/errors/) | Sentinel errors, custom types, `errors.Is`/`As`, wrapping with `%w`, `errors.Join` |
+| [recover](examples/recover/) | Panic handling with `recover` |
+
+### HTTP
+
+| Directory | Description |
+|-----------|-------------|
+| [http-server](examples/http-server/) | stdlib HTTP server with middleware chain and graceful shutdown |
+| [http-client](examples/http-client/) | HTTP client with retries, exponential backoff, and context cancellation |
+| [gin](examples/gin/) | Minimal API with Gin framework |
+| [redis](examples/redis/) | Task queue over Redis with Gin (go-redis v9) |
+
+### Language Features
+
+| Directory | Description |
+|-----------|-------------|
+| [context](examples/context/) | Cancellation, deadlines, and `context.Value` propagation |
+| [generics](examples/generics/) | `Map`, `Filter`, `Reduce`, `cmp.Ordered`, `Option[T]` |
+| [iterator](examples/iterator/) | Range-over-func iterators (`iter.Seq`) — Go 1.23 |
+| [embed](examples/embed/) | Compile static files into the binary with `//go:embed` |
+| [functional-options](examples/functional-options/) | Configure structs without exporting fields or multiplying constructors |
+
+### Observability & Performance
+
+| Directory | Description |
+|-----------|-------------|
+| [slog](examples/slog/) | Structured logging with `log/slog` (Go 1.21) |
+| [metric](examples/metric/) | StatsD metrics to Datadog |
+| [profiling](examples/profiling/) | CPU/memory profiling with `pkg/profile` |
+| [benchmark](examples/benchmark/) | Benchmarks with `testing.B` |
+| [reflection-bench](examples/reflection-bench/) | type switch vs type assertion vs interface |
+| [typecast](examples/typecast/) | Benchmark: dispatch strategies compared |
+
+### Testing
+
+| Directory | Description |
+|-----------|-------------|
+| [testing-patterns](examples/testing-patterns/) | Table-driven tests, `t.Parallel`, subtests, fuzz testing |
+| [testing](examples/testing/) | Basic unit tests |
+
+### Patterns & Design
+
+| Directory | Description |
+|-----------|-------------|
+| [inject](examples/inject/) | Constructor dependency injection with interfaces |
+| [wire](examples/wire/) | Compile-time DI code generation with Wire |
+| [oop](examples/oop/) | Methods, interfaces, and polymorphism |
+| [oop/composition](examples/oop/composition/) | Struct embedding as alternative to inheritance |
+
+### Serialization
+
+| Directory | Description |
+|-----------|-------------|
+| [serialization](examples/serialization/) | Flexible JSON: field that is either an object or array |
+| [protobuf](examples/protobuf/) | Binary serialization with Protocol Buffers |
+
+### Cloud & Infrastructure
+
+| Directory | Description |
+|-----------|-------------|
+| [dynamodb](examples/dynamodb/) | DynamoDB CRUD with AWS SDK v1 |
+| [lambda](examples/lambda/) | AWS Lambda function |
+| [mysql](examples/mysql/) | MySQL connection and queries |
+
+### Standard Library
+
+| Directory | Description |
+|-----------|-------------|
+| [config](examples/config/) | Reading JSON config with `encoding/json` |
+| [datetime-parse](examples/datetime-parse/) | Parsing dates in multiple formats |
+| [flags](examples/flags/) | Command-line flags with `flag` |
+
+---
 
 ## Running an example
 
 ```bash
-go run ./examples/channels/
-go run ./examples/gin/
+go run ./examples/context/
+go run ./examples/generics/
+go run ./examples/http-server/
 go run ./examples/concurrency/worker-pool/
 ```
 
 ## Tests
 
 ```bash
-# All tests
-go test ./...
-
-# With race detector
+# All tests with race detector
 go test -race ./...
 
-# DynamoDB integration tests (requires local DynamoDB on :8000)
+# A specific example
+go test ./examples/testing-patterns/...
+
+# Fuzz test (runs until interrupted)
+go test -fuzz=FuzzAdd ./examples/testing-patterns/
+
+# DynamoDB integration tests (requires the dynamodb service below)
 DYNAMODB_LOCAL=1 go test ./examples/dynamodb/...
 ```
 
-## External service requirements
+## Infrastructure (Docker Compose)
 
-| Example | Requirement |
-|---------|-------------|
-| `dynamodb/` | DynamoDB Local or AWS credentials |
-| `redis/` | Redis on `localhost:6379` |
-| `mysql/` | Accessible MySQL instance |
-| `metric/` | StatsD listener on `localhost:8125` |
-| `protobuf/` | `protoc` + `protoc-gen-go` to regenerate `.pb.go` |
+Several examples need a real service to connect to. Start all services at once:
+
+```bash
+docker compose up -d
+```
+
+Or bring up only what you need:
+
+```bash
+docker compose up -d redis          # examples/redis
+docker compose up -d mysql          # examples/mysql
+docker compose up -d dynamodb       # examples/dynamodb
+docker compose up -d statsd         # examples/metric
+```
+
+Stop and clean up:
+
+```bash
+docker compose down
+```
+
+| Service | Port | Used by |
+|---------|------|---------|
+| Redis 7 | `6379` | `examples/redis` |
+| MySQL 8 | `3306` | `examples/mysql` — user `root`, password `secret`, db `examples` |
+| DynamoDB Local | `8000` | `examples/dynamodb` — set `DYNAMODB_LOCAL=1` for tests |
+| StatsD | `8125/udp` | `examples/metric` |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+
+  # ── Redis ──────────────────────────────────────────────────────────────────
+  # Used by: examples/redis
+  # Connect: localhost:6379
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # ── MySQL ──────────────────────────────────────────────────────────────────
+  # Used by: examples/mysql
+  # Connect: localhost:3306, user=root password=secret database=examples
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: secret
+      MYSQL_DATABASE: examples
+    ports:
+      - "3306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-psecret"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # ── DynamoDB Local ─────────────────────────────────────────────────────────
+  # Used by: examples/dynamodb
+  # Connect: http://localhost:8000
+  # Run tests: DYNAMODB_LOCAL=1 go test ./examples/dynamodb/...
+  dynamodb:
+    image: amazon/dynamodb-local:latest
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-inMemory"]
+    ports:
+      - "8000:8000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/shell/ || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # ── StatsD / Datadog Agent (metric example) ────────────────────────────────
+  # Used by: examples/metric
+  # A lightweight StatsD sink that prints received metrics to stdout.
+  # Connect: localhost:8125 (UDP)
+  statsd:
+    image: ghcr.io/statsd/statsd:latest
+    ports:
+      - "8125:8125/udp"
+      - "8126:8126"

--- a/examples/context/main.go
+++ b/examples/context/main.go
@@ -1,0 +1,102 @@
+// Context propagation: cancellation, deadlines, and value passing.
+// context.Context is the standard mechanism for controlling goroutine lifetimes
+// and threading request-scoped values across API boundaries.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+func main() {
+	cancelExample()
+	timeoutExample()
+	valueExample()
+}
+
+// cancelExample: parent cancels work before it finishes.
+func cancelExample() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	result := make(chan string, 1)
+	go func() {
+		if err := slowOp(ctx, 500*time.Millisecond, result); err != nil {
+			result <- fmt.Sprintf("cancelled: %v", err)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel() // signal cancellation before slowOp finishes
+
+	fmt.Println("cancelExample:", <-result)
+}
+
+// timeoutExample: operation races against an automatic deadline.
+func timeoutExample() {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	result := make(chan string, 1)
+	go func() {
+		if err := slowOp(ctx, 500*time.Millisecond, result); err != nil {
+			result <- fmt.Sprintf("timeout: %v", err)
+		}
+	}()
+
+	fmt.Println("timeoutExample:", <-result)
+}
+
+// slowOp simulates work that respects ctx cancellation.
+func slowOp(ctx context.Context, d time.Duration, out chan<- string) error {
+	select {
+	case <-time.After(d):
+		out <- "completed"
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// valueExample: thread a request ID through a call chain without changing signatures.
+// Use context values sparingly — only for request-scoped data, not function parameters.
+type ctxKey string
+
+const requestIDKey ctxKey = "requestID"
+
+func valueExample() {
+	ctx := context.WithValue(context.Background(), requestIDKey, "req-abc-123")
+	processRequest(ctx)
+}
+
+func processRequest(ctx context.Context) {
+	id, ok := ctx.Value(requestIDKey).(string)
+	if !ok {
+		fmt.Println("valueExample: no request ID in context")
+		return
+	}
+
+	// Cancellation propagates: a child context inherits the parent's deadline.
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	if err := fetchData(ctx, id); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			fmt.Printf("valueExample: [%s] deadline exceeded\n", id)
+			return
+		}
+		fmt.Printf("valueExample: [%s] error: %v\n", id, err)
+		return
+	}
+	fmt.Printf("valueExample: [%s] done\n", id)
+}
+
+func fetchData(ctx context.Context, id string) error {
+	select {
+	case <-time.After(50 * time.Millisecond):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/examples/embed/main.go
+++ b/examples/embed/main.go
@@ -1,0 +1,58 @@
+// //go:embed compiles static files into the binary at build time.
+// The embedded FS behaves like io/fs.FS, so it works with http.FileServer,
+// template parsing, and any io/fs-aware API.
+package main
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+//go:embed static/hello.txt
+var helloText string
+
+//go:embed static/config.json
+var configJSON []byte
+
+//go:embed static
+var staticFS embed.FS
+
+type appConfig struct {
+	Version      string            `json:"version"`
+	FeatureFlags map[string]bool   `json:"feature_flags"`
+}
+
+func main() {
+	// Embed a single file as a string.
+	fmt.Println("=== embedded string ===")
+	fmt.Print(helloText)
+
+	// Embed a single file as bytes, decode as JSON.
+	fmt.Println("=== embedded JSON ===")
+	var cfg appConfig
+	if err := json.Unmarshal(configJSON, &cfg); err != nil {
+		panic(err)
+	}
+	fmt.Printf("version: %s\n", cfg.Version)
+	for flag, enabled := range cfg.FeatureFlags {
+		fmt.Printf("  %s: %v\n", flag, enabled)
+	}
+
+	// Embed a whole directory as an fs.FS.
+	fmt.Println("=== embedded directory ===")
+	fs.WalkDir(staticFS, "static", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, _ := staticFS.ReadFile(path)
+		preview := strings.TrimSpace(string(data))
+		if len(preview) > 40 {
+			preview = preview[:40]
+		}
+		fmt.Printf("%s (%d bytes): %s\n", path, len(data), preview)
+		return nil
+	})
+}

--- a/examples/embed/static/config.json
+++ b/examples/embed/static/config.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "feature_flags": {
+    "new_ui": true,
+    "dark_mode": false
+  }
+}

--- a/examples/embed/static/hello.txt
+++ b/examples/embed/static/hello.txt
@@ -1,0 +1,2 @@
+Hello from an embedded file!
+This file is compiled into the binary at build time.

--- a/examples/errgroup/main.go
+++ b/examples/errgroup/main.go
@@ -1,0 +1,98 @@
+// errgroup runs a group of goroutines and collects the first error.
+// It replaces the common WaitGroup + error channel pattern with less boilerplate.
+// errgroup.WithContext also cancels the shared context when any goroutine fails,
+// so sibling goroutines can stop early.
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type result struct {
+	id    int
+	value string
+}
+
+// fetchAll runs N fetches concurrently and returns all results or the first error.
+func fetchAll(ctx context.Context, ids []int) ([]result, error) {
+	results := make([]result, len(ids))
+
+	g, ctx := errgroup.WithContext(ctx)
+	for i, id := range ids {
+		i, id := i, id // capture loop variables
+		g.Go(func() error {
+			r, err := fetch(ctx, id)
+			if err != nil {
+				return fmt.Errorf("fetch %d: %w", id, err)
+			}
+			results[i] = r
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func fetch(ctx context.Context, id int) (result, error) {
+	select {
+	case <-ctx.Done():
+		return result{}, ctx.Err()
+	case <-time.After(time.Duration(id*10) * time.Millisecond):
+		return result{id: id, value: fmt.Sprintf("data-%d", id)}, nil
+	}
+}
+
+// fetchWithLimit uses errgroup's SetLimit to cap concurrent goroutines.
+// Useful when calling a rate-limited downstream service.
+func fetchWithLimit(ctx context.Context, ids []int, concurrency int) ([]result, error) {
+	results := make([]result, len(ids))
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for i, id := range ids {
+		i, id := i, id
+		g.Go(func() error {
+			r, err := fetch(ctx, id)
+			if err != nil {
+				return fmt.Errorf("fetch %d: %w", id, err)
+			}
+			results[i] = r
+			return nil
+		})
+	}
+
+	return results, g.Wait()
+}
+
+func main() {
+	ctx := context.Background()
+	ids := []int{1, 2, 3, 4, 5}
+
+	fmt.Println("--- unbounded concurrency ---")
+	results, err := fetchAll(ctx, ids)
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		for _, r := range results {
+			fmt.Printf("  %d: %s\n", r.id, r.value)
+		}
+	}
+
+	fmt.Println("--- limited to 2 concurrent ---")
+	results, err = fetchWithLimit(ctx, ids, 2)
+	if err != nil {
+		fmt.Println("error:", err)
+	} else {
+		for _, r := range results {
+			fmt.Printf("  %d: %s\n", r.id, r.value)
+		}
+	}
+}

--- a/examples/errors/main.go
+++ b/examples/errors/main.go
@@ -1,0 +1,77 @@
+// Error handling patterns: sentinel errors, custom error types, wrapping and unwrapping.
+// errors.Is checks identity; errors.As unwraps to a concrete type.
+// %w in fmt.Errorf wraps an error so both functions can traverse the chain.
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// --- sentinel errors ---
+
+var (
+	ErrNotFound   = errors.New("not found")
+	ErrForbidden  = errors.New("forbidden")
+)
+
+// --- custom error type ---
+
+// ValidationError carries the field name and a description of the constraint violation.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validation failed on %q: %s", e.Field, e.Message)
+}
+
+// --- a layered call chain ---
+
+func findUser(id int) error {
+	if id <= 0 {
+		return &ValidationError{Field: "id", Message: "must be positive"}
+	}
+	if id > 100 {
+		// Wrap the sentinel so callers can inspect it with errors.Is.
+		return fmt.Errorf("findUser(%d): %w", id, ErrNotFound)
+	}
+	return nil
+}
+
+func loadProfile(userID int) error {
+	if err := findUser(userID); err != nil {
+		// Wrap again: the original error is still reachable via Unwrap.
+		return fmt.Errorf("loadProfile: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	// Case 1: sentinel error — errors.Is traverses the wrap chain.
+	err := loadProfile(999)
+	fmt.Println("is ErrNotFound:", errors.Is(err, ErrNotFound))
+	fmt.Println("error:", err)
+	fmt.Println()
+
+	// Case 2: custom error type — errors.As unwraps to *ValidationError.
+	err = loadProfile(-1)
+	var valErr *ValidationError
+	if errors.As(err, &valErr) {
+		fmt.Printf("validation error on field %q: %s\n", valErr.Field, valErr.Message)
+	}
+	fmt.Println()
+
+	// Case 3: no error.
+	err = loadProfile(42)
+	fmt.Println("no error:", err)
+	fmt.Println()
+
+	// Case 4: joining multiple errors (Go 1.20+).
+	errs := []error{ErrNotFound, ErrForbidden}
+	joined := errors.Join(errs...)
+	fmt.Println("joined:", joined)
+	fmt.Println("is ErrNotFound:", errors.Is(joined, ErrNotFound))
+	fmt.Println("is ErrForbidden:", errors.Is(joined, ErrForbidden))
+}

--- a/examples/functional-options/main.go
+++ b/examples/functional-options/main.go
@@ -1,0 +1,81 @@
+// Functional options pattern: configure a struct without exporting its fields
+// or multiplying constructor overloads.
+// Each option is a function that modifies the internal config, so new options
+// are added without breaking existing callers.
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+type serverConfig struct {
+	host         string
+	port         int
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+	maxConns     int
+}
+
+// Option is a function that applies one setting to serverConfig.
+type Option func(*serverConfig)
+
+func WithHost(host string) Option {
+	return func(c *serverConfig) { c.host = host }
+}
+
+func WithPort(port int) Option {
+	return func(c *serverConfig) { c.port = port }
+}
+
+func WithReadTimeout(d time.Duration) Option {
+	return func(c *serverConfig) { c.readTimeout = d }
+}
+
+func WithWriteTimeout(d time.Duration) Option {
+	return func(c *serverConfig) { c.writeTimeout = d }
+}
+
+func WithMaxConns(n int) Option {
+	return func(c *serverConfig) { c.maxConns = n }
+}
+
+// Server holds the resolved configuration.
+type Server struct {
+	cfg serverConfig
+}
+
+// NewServer applies options on top of sensible defaults.
+// Callers only specify what differs from the defaults.
+func NewServer(opts ...Option) *Server {
+	cfg := serverConfig{
+		host:         "0.0.0.0",
+		port:         8080,
+		readTimeout:  5 * time.Second,
+		writeTimeout: 10 * time.Second,
+		maxConns:     100,
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return &Server{cfg: cfg}
+}
+
+func (s *Server) Addr() string {
+	return fmt.Sprintf("%s:%d", s.cfg.host, s.cfg.port)
+}
+
+func main() {
+	// Minimal — all defaults.
+	s1 := NewServer()
+	fmt.Printf("default server: addr=%s maxConns=%d\n", s1.Addr(), s1.cfg.maxConns)
+
+	// Override only what's needed.
+	s2 := NewServer(
+		WithPort(9090),
+		WithReadTimeout(30*time.Second),
+		WithMaxConns(500),
+	)
+	fmt.Printf("custom server:  addr=%s readTimeout=%s maxConns=%d\n",
+		s2.Addr(), s2.cfg.readTimeout, s2.cfg.maxConns)
+}

--- a/examples/generics/main.go
+++ b/examples/generics/main.go
@@ -1,0 +1,103 @@
+// Generics (Go 1.18+): type parameters eliminate repetitive code for collections.
+// Constraints define the set of types a type parameter accepts.
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+)
+
+// --- generic collection functions ---
+
+// Map transforms each element of a slice using f.
+func Map[T, U any](s []T, f func(T) U) []U {
+	out := make([]U, len(s))
+	for i, v := range s {
+		out[i] = f(v)
+	}
+	return out
+}
+
+// Filter returns elements for which keep returns true.
+func Filter[T any](s []T, keep func(T) bool) []T {
+	var out []T
+	for _, v := range s {
+		if keep(v) {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// Reduce folds a slice into a single value using f, starting from initial.
+func Reduce[T, U any](s []T, initial U, f func(U, T) U) U {
+	acc := initial
+	for _, v := range s {
+		acc = f(acc, v)
+	}
+	return acc
+}
+
+// --- constrained generics ---
+
+// Min returns the smallest element in a non-empty slice.
+// cmp.Ordered covers all built-in ordered types (integers, floats, strings).
+func Min[T cmp.Ordered](s []T) T {
+	if len(s) == 0 {
+		panic("Min called on empty slice")
+	}
+	return slices.Min(s)
+}
+
+// Keys returns the keys of a map in unspecified order.
+func Keys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// --- generic optional type ---
+
+// Option[T] avoids nil pointer pitfalls by making absence explicit.
+type Option[T any] struct {
+	value *T
+}
+
+func Some[T any](v T) Option[T] { return Option[T]{value: &v} }
+func None[T any]() Option[T]    { return Option[T]{} }
+
+func (o Option[T]) IsPresent() bool    { return o.value != nil }
+func (o Option[T]) Unwrap() T          { return *o.value }
+func (o Option[T]) OrElse(def T) T {
+	if o.value == nil {
+		return def
+	}
+	return *o.value
+}
+
+func main() {
+	nums := []int{1, 2, 3, 4, 5, 6}
+
+	doubled := Map(nums, func(n int) int { return n * 2 })
+	fmt.Println("Map (double):", doubled)
+
+	evens := Filter(nums, func(n int) bool { return n%2 == 0 })
+	fmt.Println("Filter (even):", evens)
+
+	sum := Reduce(nums, 0, func(acc, n int) int { return acc + n })
+	fmt.Println("Reduce (sum):", sum)
+
+	words := []string{"banana", "apple", "cherry"}
+	fmt.Println("Min string:", Min(words))
+
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+	keys := Keys(m)
+	slices.Sort(keys)
+	fmt.Println("Keys:", keys)
+
+	fmt.Println("Some(42).OrElse(0):", Some(42).OrElse(0))
+	fmt.Println("None[int]().OrElse(0):", None[int]().OrElse(0))
+}

--- a/examples/http-client/main.go
+++ b/examples/http-client/main.go
@@ -1,0 +1,111 @@
+// HTTP client patterns: timeouts, retries with backoff, context cancellation,
+// and JSON decoding. Uses only the standard library.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"net/http"
+	"time"
+)
+
+// Client wraps http.Client with retry logic.
+type Client struct {
+	http       *http.Client
+	maxRetries int
+	baseDelay  time.Duration
+}
+
+func NewClient(timeout time.Duration, maxRetries int) *Client {
+	return &Client{
+		http:       &http.Client{Timeout: timeout},
+		maxRetries: maxRetries,
+		baseDelay:  200 * time.Millisecond,
+	}
+}
+
+// GetJSON fetches a URL and decodes the JSON body into dst.
+// It retries on 5xx responses and network errors, backing off exponentially.
+func (c *Client) GetJSON(ctx context.Context, url string, dst any) error {
+	var lastErr error
+	for attempt := range c.maxRetries + 1 {
+		if attempt > 0 {
+			delay := time.Duration(float64(c.baseDelay) * math.Pow(2, float64(attempt-1)))
+			slog.Info("retrying", "attempt", attempt, "delay", delay, "url", url)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled during backoff: %w", ctx.Err())
+			}
+		}
+
+		if err := c.doGet(ctx, url, dst); err != nil {
+			lastErr = err
+			var retryable *retryableError
+			if !errors.As(err, &retryable) {
+				return err // non-retryable: propagate immediately
+			}
+			slog.Warn("retryable error", "error", err)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("all %d attempts failed: %w", c.maxRetries+1, lastErr)
+}
+
+type retryableError struct{ cause error }
+
+func (e *retryableError) Error() string  { return fmt.Sprintf("retryable: %v", e.cause) }
+func (e *retryableError) Unwrap() error  { return e.cause }
+
+func (c *Client) doGet(ctx context.Context, url string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return &retryableError{cause: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 {
+		return &retryableError{cause: fmt.Errorf("server error: %s", resp.Status)}
+	}
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("client error: %s", resp.Status)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+type Post struct {
+	ID    int    `json:"id"`
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+func main() {
+	client := NewClient(5*time.Second, 3)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var post Post
+	url := "https://jsonplaceholder.typicode.com/posts/1"
+	if err := client.GetJSON(ctx, url, &post); err != nil {
+		slog.Error("request failed", "error", err)
+		return
+	}
+
+	fmt.Printf("Post #%d: %s\n", post.ID, post.Title)
+}

--- a/examples/http-server/main.go
+++ b/examples/http-server/main.go
@@ -1,0 +1,117 @@
+// Minimal HTTP server using only the standard library.
+// Shows routing, JSON responses, middleware chaining, and graceful shutdown.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+// --- middleware ---
+
+func logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		slog.Info("request", "method", r.Method, "path", r.URL.Path, "duration", time.Since(start))
+	})
+}
+
+func recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				slog.Error("panic recovered", "error", rec)
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+func chain(h http.Handler, middlewares ...func(http.Handler) http.Handler) http.Handler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		h = middlewares[i](h)
+	}
+	return h
+}
+
+// --- handlers ---
+
+type envelope struct {
+	Data any    `json:"data,omitempty"`
+	Err  string `json:"error,omitempty"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, envelope{Data: map[string]string{"status": "ok"}})
+}
+
+func handleEcho(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, envelope{Err: "invalid JSON"})
+		return
+	}
+	writeJSON(w, http.StatusOK, envelope{Data: body})
+}
+
+func handlePanic(_ http.ResponseWriter, _ *http.Request) {
+	panic("intentional panic — recovered by middleware")
+}
+
+// --- server setup ---
+
+func newRouter() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", handleHealth)
+	mux.HandleFunc("POST /echo", handleEcho)
+	mux.HandleFunc("GET /panic", handlePanic)
+	return chain(mux, logging, recoverer)
+}
+
+func main() {
+	srv := &http.Server{
+		Addr:         ":8080",
+		Handler:      newRouter(),
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	// Graceful shutdown on SIGINT / SIGTERM.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		slog.Info("server started", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server error", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	<-quit
+	slog.Info("shutting down...")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Error("shutdown error", "error", err)
+	}
+}

--- a/examples/iterator/main.go
+++ b/examples/iterator/main.go
@@ -1,0 +1,81 @@
+// Range-over-func iterators (Go 1.23): functions with signature func(yield func(V) bool)
+// can be used directly in a for-range loop.
+// This lets you build lazy iterators without materialising a full slice.
+package main
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+)
+
+// Filter returns an iterator that yields only elements satisfying pred.
+func Filter[V any](seq iter.Seq[V], pred func(V) bool) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		for v := range seq {
+			if pred(v) {
+				if !yield(v) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// Map transforms each element of seq using f.
+func Map[V, W any](seq iter.Seq[V], f func(V) W) iter.Seq[W] {
+	return func(yield func(W) bool) {
+		for v := range seq {
+			if !yield(f(v)) {
+				return
+			}
+		}
+	}
+}
+
+// Take yields at most n elements from seq.
+func Take[V any](seq iter.Seq[V], n int) iter.Seq[V] {
+	return func(yield func(V) bool) {
+		count := 0
+		for v := range seq {
+			if count >= n {
+				return
+			}
+			if !yield(v) {
+				return
+			}
+			count++
+		}
+	}
+}
+
+// Naturals is an infinite iterator of integers starting at start.
+func Naturals(start int) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for i := start; ; i++ {
+			if !yield(i) {
+				return
+			}
+		}
+	}
+}
+
+func main() {
+	// Collect the first 5 even numbers from the infinite natural sequence.
+	evens := Filter(Naturals(1), func(n int) bool { return n%2 == 0 })
+	first5 := slices.Collect(Take(evens, 5))
+	fmt.Println("first 5 evens:", first5)
+
+	// Chain: squares of odd numbers, take 4.
+	odds := Filter(Naturals(1), func(n int) bool { return n%2 != 0 })
+	squares := Map(odds, func(n int) int { return n * n })
+	result := slices.Collect(Take(squares, 4))
+	fmt.Println("squares of first 4 odds:", result)
+
+	// for-range directly over an iterator — no intermediate slice.
+	fmt.Print("inline range: ")
+	for n := range Take(Naturals(10), 5) {
+		fmt.Print(n, " ")
+	}
+	fmt.Println()
+}

--- a/examples/slog/main.go
+++ b/examples/slog/main.go
@@ -1,0 +1,70 @@
+// Structured logging with log/slog (Go 1.21).
+// slog replaces ad-hoc log.Printf calls with structured key-value pairs
+// that JSON handlers can forward to log aggregators without post-processing.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// requestID is a typed context key to avoid collisions.
+type requestID string
+
+const reqIDKey requestID = "reqID"
+
+// withRequestID adds a request ID to the logger stored in ctx.
+func withRequestID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, reqIDKey, id)
+}
+
+// logger extracts request-scoped fields from ctx and returns a child logger.
+func logger(ctx context.Context) *slog.Logger {
+	l := slog.Default()
+	if id, ok := ctx.Value(reqIDKey).(string); ok {
+		l = l.With("request_id", id)
+	}
+	return l
+}
+
+func processOrder(ctx context.Context, orderID int) error {
+	log := logger(ctx)
+	log.Info("processing order", "order_id", orderID)
+
+	start := time.Now()
+	time.Sleep(10 * time.Millisecond) // simulate work
+	log.Info("order processed", "order_id", orderID, "duration_ms", time.Since(start).Milliseconds())
+	return nil
+}
+
+func main() {
+	// Text handler — human-readable, default to stderr.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+
+	slog.Info("application started", "version", "1.0.0")
+	slog.Debug("debug message — only visible at Debug level")
+
+	// Structured fields — the key-value pairs appear consistently in every log line.
+	slog.Warn("high memory usage", "used_mb", 512, "limit_mb", 1024, "pct", 50)
+
+	// Group related fields to avoid key collisions.
+	slog.Info("database connected",
+		slog.Group("db", "host", "localhost", "port", 5432, "name", "orders"),
+	)
+
+	// Context-aware logging: request ID propagates automatically.
+	ctx := withRequestID(context.Background(), "req-abc-123")
+	if err := processOrder(ctx, 42); err != nil {
+		logger(ctx).Error("order failed", "error", err)
+	}
+
+	// Switch to JSON handler — same API, structured output for log aggregators.
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})))
+	slog.Info("switched to JSON handler", "env", "production")
+}

--- a/examples/sync-primitives/main.go
+++ b/examples/sync-primitives/main.go
@@ -1,0 +1,102 @@
+// Synchronisation primitives: sync.Once, sync.Map, and atomic operations.
+// Each solves a specific coordination problem; choosing the right one avoids
+// unnecessary mutex contention.
+package main
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// --- sync.Once: initialise exactly once, even under concurrent access ---
+
+type expensiveService struct{ name string }
+
+var (
+	serviceInstance *expensiveService
+	once            sync.Once
+)
+
+func getService() *expensiveService {
+	once.Do(func() {
+		// This runs exactly once regardless of how many goroutines call getService.
+		serviceInstance = &expensiveService{name: "singleton"}
+		fmt.Println("service initialised")
+	})
+	return serviceInstance
+}
+
+func onceExample() {
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s := getService()
+			_ = s
+		}()
+	}
+	wg.Wait()
+	fmt.Println("once: all goroutines got", getService().name)
+}
+
+// --- sync.Map: concurrent map without a manual mutex ---
+// Optimised for two access patterns:
+//   - write-once / read-many (e.g., caches)
+//   - many goroutines each writing to disjoint keys
+
+func syncMapExample() {
+	var m sync.Map
+
+	var wg sync.WaitGroup
+	for i := range 5 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", i)
+			m.Store(key, i*i)
+		}(i)
+	}
+	wg.Wait()
+
+	m.Range(func(k, v any) bool {
+		fmt.Printf("syncMap: %s = %v\n", k, v)
+		return true
+	})
+}
+
+// --- atomic: lock-free counter and compare-and-swap ---
+
+func atomicExample() {
+	var counter atomic.Int64
+
+	var wg sync.WaitGroup
+	for range 1000 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			counter.Add(1)
+		}()
+	}
+	wg.Wait()
+	fmt.Println("atomic counter:", counter.Load()) // always 1000
+
+	// Compare-and-swap: update only if the current value matches expected.
+	var state atomic.Int32
+	swapped := state.CompareAndSwap(0, 1) // 0 → 1
+	fmt.Println("CAS (0→1):", swapped)
+	swapped = state.CompareAndSwap(0, 2) // expected 0 but got 1 — no swap
+	fmt.Println("CAS (0→2, should fail):", swapped)
+}
+
+func main() {
+	fmt.Println("=== sync.Once ===")
+	onceExample()
+
+	fmt.Println("\n=== sync.Map ===")
+	syncMapExample()
+
+	fmt.Println("\n=== atomic ===")
+	atomicExample()
+}

--- a/examples/testing-patterns/main.go
+++ b/examples/testing-patterns/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println(FizzBuzz(15)) // FizzBuzz
+	fmt.Println(FizzBuzz(9))  // Fizz
+}

--- a/examples/testing-patterns/math.go
+++ b/examples/testing-patterns/math.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrDivByZero = errors.New("division by zero")
+
+func Add(a, b int) int      { return a + b }
+func Multiply(a, b int) int { return a * b }
+
+func Divide(a, b float64) (float64, error) {
+	if b == 0 {
+		return 0, ErrDivByZero
+	}
+	return a / b, nil
+}
+
+// FizzBuzz returns "Fizz", "Buzz", "FizzBuzz", or the number as a string.
+func FizzBuzz(n int) string {
+	switch {
+	case n%15 == 0:
+		return "FizzBuzz"
+	case n%3 == 0:
+		return "Fizz"
+	case n%5 == 0:
+		return "Buzz"
+	default:
+		return fmt.Sprintf("%d", n)
+	}
+}

--- a/examples/testing-patterns/math_test.go
+++ b/examples/testing-patterns/math_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// Table-driven tests: a single test function covers many input/output pairs.
+// t.Run creates named subtests visible in go test -v output.
+func TestAdd(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a, b int
+		want int
+	}{
+		{"positive", 2, 3, 5},
+		{"negative", -2, -3, -5},
+		{"mixed", -2, 3, 1},
+		{"zeros", 0, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel() // subtests can also run in parallel
+			got := Add(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("Add(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDivide(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		a, b    float64
+		want    float64
+		wantErr error
+	}{
+		{"normal", 10, 2, 5, nil},
+		{"fraction", 1, 3, 1.0 / 3.0, nil},
+		{"by zero", 5, 0, 0, ErrDivByZero},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Divide(tc.a, tc.b)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Divide(%v, %v) error = %v, want %v", tc.a, tc.b, err, tc.wantErr)
+			}
+			if tc.wantErr == nil && got != tc.want {
+				t.Errorf("Divide(%v, %v) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFizzBuzz(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{1, "1"},
+		{3, "Fizz"},
+		{5, "Buzz"},
+		{15, "FizzBuzz"},
+		{30, "FizzBuzz"},
+		{7, "7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			t.Parallel()
+			if got := FizzBuzz(tc.n); got != tc.want {
+				t.Errorf("FizzBuzz(%d) = %q, want %q", tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+// Fuzz test (Go 1.18+): the fuzzer generates arbitrary inputs and checks invariants.
+// Run with: go test -fuzz=FuzzAdd
+func FuzzAdd(f *testing.F) {
+	// Seed corpus: known interesting inputs.
+	f.Add(0, 0)
+	f.Add(1, -1)
+	f.Add(100, 200)
+
+	f.Fuzz(func(t *testing.T, a, b int) {
+		// Invariant: Add must be commutative.
+		if Add(a, b) != Add(b, a) {
+			t.Errorf("Add(%d, %d) != Add(%d, %d)", a, b, b, a)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/profile v1.7.0
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/stretchr/testify v1.9.0
+	golang.org/x/sync v0.21.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
## Summary

Adds 12 new examples covering modern Go features and patterns, plus a `docker-compose.yml` for examples that need real services.

### New examples

| Example | What it shows |
|---------|---------------|
| `context/` | `WithCancel`, `WithTimeout`, value propagation, cancellation in goroutines |
| `errgroup/` | `errgroup.WithContext`, `SetLimit` for bounded concurrency, vs manual WaitGroup |
| `errors/` | Sentinel errors, custom error types, `errors.Is`/`As`, `%w` wrap chain, `errors.Join` (Go 1.20) |
| `generics/` | `Map`/`Filter`/`Reduce`, `cmp.Ordered`, `Keys[K,V]`, `Option[T]` |
| `http-server/` | stdlib mux, middleware chain (`logging`, `recoverer`), graceful shutdown |
| `http-client/` | Retries with exponential backoff, typed `retryableError`, context cancellation |
| `slog/` | `log/slog` text + JSON handlers, context-aware child loggers (Go 1.21) |
| `functional-options/` | Configuring structs via `Option` functions over defaults |
| `iterator/` | `iter.Seq` range-over-func, lazy `Filter`/`Map`/`Take`, infinite sequences (Go 1.23) |
| `embed/` | `//go:embed` for string, `[]byte`, and `fs.FS`; walking an embedded directory |
| `sync-primitives/` | `sync.Once`, `sync.Map`, `atomic.Int64`, `CompareAndSwap` |
| `testing-patterns/` | Table-driven tests, `t.Parallel`, named subtests, fuzz test with `FuzzAdd` |

### Docker Compose

```bash
docker compose up -d          # Redis, MySQL, DynamoDB Local, StatsD
docker compose up -d redis    # only Redis
```

Services: Redis 7 (:6379), MySQL 8 (:3306), DynamoDB Local (:8000), StatsD (:8125/udp)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test -race ./...` passes
- [ ] `go run ./examples/generics/` shows Map/Filter/Reduce/Option output
- [ ] `go run ./examples/context/` shows cancel + timeout + value examples
- [ ] `go run ./examples/errors/` shows Is/As/Join
- [ ] `go run ./examples/iterator/` shows lazy sequences
- [ ] `go test -fuzz=FuzzAdd ./examples/testing-patterns/` runs without panic
- [ ] `docker compose up -d && go run ./examples/redis/` connects to Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)