### PR TITLE
Make Makefile/CI iterate every go.work module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,13 +25,13 @@ jobs:
           cache: true
 
       - name: Build
-        run: go build ./...
+        run: make build
 
       - name: Vet
-        run: go vet ./...
+        run: make vet
 
       - name: Test (with race detector)
-        run: go test -race -count=1 ./...
+        run: make test
 
   # ── go mod tidy check ───────────────────────────────────────────────────────
   tidy:
@@ -45,10 +45,10 @@ jobs:
           go-version: "1.25"
           cache: true
 
-      - name: Check go mod tidy
+      - name: Check go mod tidy (every workspace module)
         run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum
+          make tidy
+          git diff --exit-code
 
   # ── lint ────────────────────────────────────────────────────────────────────
   lint:
@@ -65,8 +65,8 @@ jobs:
       - name: Install golangci-lint v2
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
-      - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m ./...
+      - name: Run golangci-lint (every workspace module)
+        run: make lint
 
   # ── security ────────────────────────────────────────────────────────────────
   security:
@@ -83,5 +83,5 @@ jobs:
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: Run govulncheck
-        run: govulncheck ./...
+      - name: Run govulncheck (every workspace module)
+        run: make vuln

--- a/Makefile
+++ b/Makefile
@@ -7,36 +7,53 @@ help:
 	@echo "Usage:"
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' | sed -e 's/^/ /'
 
-## build: compile all examples
+## build: compile every workspace module (root + each migrated example)
 .PHONY: build
 build:
-	go build ./...
+	@for d in $$(go list -m -f '{{.Dir}}'); do \
+		echo "==> build $$d"; \
+		(cd "$$d" && go build ./...) || exit 1; \
+	done
 
-## test: run all tests with the race detector
+## test: run all tests with the race detector, in every workspace module
 .PHONY: test
 test:
-	go test -race -count=1 ./...
+	@for d in $$(go list -m -f '{{.Dir}}'); do \
+		echo "==> test $$d"; \
+		(cd "$$d" && go test -race -count=1 ./...) || exit 1; \
+	done
 
-## vet: run go vet
+## vet: run go vet in every workspace module
 .PHONY: vet
 vet:
-	go vet ./...
+	@for d in $$(go list -m -f '{{.Dir}}'); do \
+		echo "==> vet $$d"; \
+		(cd "$$d" && go vet ./...) || exit 1; \
+	done
 
-## lint: run golangci-lint (requires golangci-lint in PATH)
+## lint: run golangci-lint in every workspace module (requires golangci-lint in PATH)
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	@for d in $$(go list -m -f '{{.Dir}}'); do \
+		echo "==> lint $$d"; \
+		(cd "$$d" && golangci-lint run --timeout=5m ./...) || exit 1; \
+	done
 
-## vuln: run govulncheck (requires govulncheck in PATH)
+## vuln: run govulncheck in every workspace module (requires govulncheck in PATH)
 .PHONY: vuln
 vuln:
-	govulncheck ./...
+	@for d in $$(go list -m -f '{{.Dir}}'); do \
+		echo "==> vuln $$d"; \
+		(cd "$$d" && govulncheck ./...) || exit 1; \
+	done
 
-## tidy: tidy and verify go.mod / go.sum
+## tidy: tidy and verify go.mod / go.sum in every workspace module
 .PHONY: tidy
 tidy:
-	go mod tidy
-	go mod verify
+	@for d in $$(go list -m -f '{{.Dir}}'); do \
+		echo "==> tidy $$d"; \
+		(cd "$$d" && go mod tidy && go mod verify) || exit 1; \
+	done
 
 ## run: run a specific example  (usage: make run EXAMPLE=context)
 .PHONY: run


### PR DESCRIPTION
## Summary
- Prerequisite for migrating individual examples to their own Go module (per `CONTRIBUTING.md`'s standalone-module standard): with `go.work`, root-level `go build ./...` / `go vet ./...` / `golangci-lint run ./...` only cover the root module and silently skip every other workspace module.
- Verified empirically: registered a throwaway module in `go.work`, injected an unused-variable bug, and confirmed `golangci-lint run ./...` at repo root reported "0 issues" while running it inside that module's directory caught it immediately.
- `build`/`test`/`vet`/`lint`/`vuln`/`tidy` Makefile targets now loop over `go list -m -f '{{.Dir}}'` (all workspace modules) instead of running once at root; CI (`build.yml`) now calls `make build`/`make vet`/`make test`/`make lint`/`make vuln`, and the tidy job runs `make tidy` then checks the whole tree for diffs.
- No behavior change today — `go.work` currently only lists the root module, so every target still runs exactly once, same as before (verified locally: `make build`, `make vet`, `make lint`, `make test`, `make tidy` all pass unchanged).

## Test plan
- [x] `make build`, `make vet`, `make lint`, `make test`, `make tidy` pass locally against current `go.work` (root-only)
- [x] Simulated a second workspace module locally with an injected lint/build error and confirmed the new loop catches it (root-only invocation did not)
- [x] CI will validate the same commands via the updated workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)