### PR TITLE
Migrate concurrency/fan-out-timeout to standalone-module standard

### DIFF
--- a/examples/concurrency/fan-out-timeout/Makefile
+++ b/examples/concurrency/fan-out-timeout/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/concurrency/fan-out-timeout/README.md
+++ b/examples/concurrency/fan-out-timeout/README.md
@@ -1,0 +1,81 @@
+# Fan-Out with Per-Worker Timeout
+
+**Category:** concurrency
+**Difficulty:** Intermediate
+
+## Objective
+
+Show how to bound how long you'll wait for any single goroutine in a fan-out, using `select` racing the real result against `time.After`, so one slow worker can't stall the whole batch.
+
+## Concepts Covered
+
+- `select` racing two channels: a real result vs. a deadline
+- `time.After` as a one-shot timeout channel
+- Isolating each worker's timeout so slow workers degrade gracefully instead of blocking everything
+- Fanning out N goroutines and gathering results through a buffered channel (same shape as [scatter-gather](../scatter-gather/))
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+fan-out-timeout/
+├── go.mod
+├── main.go
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+Each of the 10 workers simulates a random delay up to 500ms against a 300ms timeout, so roughly 40% time out on average — the exact count and worker IDs vary between runs:
+
+```
+worker 1 done in 58ms
+worker 2 done in 135ms
+worker 4 done in 155ms
+worker 7 done in 182ms
+worker 6 done in 201ms
+worker 9 timed out
+worker 10 timed out
+worker 8 timed out
+worker 5 timed out
+worker 3 timed out
+
+5/10 workers timed out
+```
+
+## Code Walkthrough
+
+- Each `worker` starts an inner goroutine that does the actual (simulated) work and writes to a private, buffered `done` channel.
+- The outer `worker` function then `select`s between `<-done` (the real result) and `<-time.After(workerTimeout)`. Whichever fires first wins.
+- If the timeout wins, `worker` sends a sentinel `result{timedOut: true, ...}` to `out` instead of the real value — the inner goroutine is left to finish on its own time and write to `done`, which nobody will read again (safe because `done` is buffered with capacity 1, so that final send doesn't block and the goroutine can exit).
+- `main` fans out all 10 workers, waits for all of them via `wg.Wait()` (every `worker` call returns once it has produced *a* result — real or timeout — not once the inner goroutine finishes), then tallies how many timed out.
+
+## Common Pitfalls
+
+- **Unbuffered `done` channel.** If `done` weren't buffered, the inner goroutine's send would block forever after a timeout (nobody is still receiving), leaking the goroutine permanently. Buffering it with capacity 1 lets that final send always succeed.
+- **Assuming the timed-out inner goroutine is cancelled.** `time.After` racing in a `select` does not stop the other branch's work — it only stops *waiting* for it. If the underlying work needs to actually be cancelled (e.g., an in-flight HTTP request), use `context.WithTimeout` instead, which propagates cancellation.
+- **Reusing `time.After` in a loop.** Each call allocates a new timer that isn't garbage-collected until it fires; fine for a one-shot `select` like this, but wasteful in a hot loop — use `time.NewTimer` + `Stop()`/`Reset()` there instead.
+- **Treating the timeout ratio as deterministic.** With `math/rand` unseeded delays, the exact count of timeouts (and which worker IDs) changes every run — don't write a test that asserts an exact count.
+
+## References
+
+- [Go Blog — Go Concurrency Patterns: Timing out, moving on](https://go.dev/blog/context)
+- [Effective Go — Select](https://go.dev/doc/effective_go#select)
+
+## Next Steps
+
+- [context](../../context/) — replace `time.After` with `context.WithTimeout` for real cancellation propagation
+- [concurrency/scatter-gather](../scatter-gather/) — the same fan-out shape without a timeout
+- [errgroup](../../errgroup/) — structured error handling across a fan-out

--- a/examples/concurrency/fan-out-timeout/go.mod
+++ b/examples/concurrency/fan-out-timeout/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/concurrency/fan-out-timeout
+
+go 1.25.0

--- a/examples/concurrency/fan-out-timeout/main.go
+++ b/examples/concurrency/fan-out-timeout/main.go
@@ -12,8 +12,8 @@ import (
 const workerTimeout = 300 * time.Millisecond
 
 type result struct {
-	id      int
-	message string
+	id       int
+	message  string
 	timedOut bool
 }
 

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.25.0
 use (
 	.
 	./examples/channels
+	./examples/concurrency/fan-out-timeout
 	./examples/concurrency/scatter-gather
 	./examples/concurrency/worker-pool
 )


### PR DESCRIPTION
## Summary
- Migrates `examples/concurrency/fan-out-timeout` to its own module + full README per `CONTRIBUTING.md`, tagged `concurrency` / `Intermediate`.
- Also gofmt's `main.go` (pre-existing struct field alignment drift) since gofmt-clean is required by the new standard.
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `make run` output matches the documented (non-deterministic) expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)