### PR TITLE
Migrate embed to standalone-module standard

### DIFF
--- a/examples/embed/Makefile
+++ b/examples/embed/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/embed/README.md
+++ b/examples/embed/README.md
@@ -1,0 +1,84 @@
+# Embed
+
+**Category:** basics
+**Difficulty:** Beginner
+
+## Objective
+
+Show the three shapes of `//go:embed`: a single file as a `string`, a single file as `[]byte`, and a whole directory as an `embed.FS` — all compiled directly into the binary, with no filesystem access needed at runtime.
+
+## Concepts Covered
+
+- `//go:embed` directives on package-level `string`, `[]byte`, and `embed.FS` variables
+- `embed.FS` implementing `io/fs.FS`, so it works with `fs.WalkDir`, `ReadFile`, and any `io/fs`-aware API
+- Decoding embedded JSON bytes with `encoding/json`
+- Why embedded assets remove a runtime dependency on the working directory (contrast with [config](../config/), which reads `config.json` from disk)
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+embed/
+├── go.mod
+├── main.go
+├── static/
+│   ├── config.json
+│   └── hello.txt
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+The two feature-flag lines print in random order — Go intentionally randomizes map iteration — everything else is fixed:
+
+```
+=== embedded string ===
+Hello from an embedded file!
+This file is compiled into the binary at build time.
+=== embedded JSON ===
+version: 1.0.0
+  new_ui: true
+  dark_mode: false
+=== embedded directory ===
+static/config.json (94 bytes): {
+  "version": "1.0.0",
+  "feature_flags
+static/hello.txt (82 bytes): Hello from an embedded file!
+This file i
+```
+
+## Code Walkthrough
+
+- `//go:embed static/hello.txt` above a `string` variable embeds that one file's contents directly as text.
+- `//go:embed static/config.json` above a `[]byte` variable embeds the raw bytes, which are then decoded with `json.Unmarshal` into `appConfig`.
+- `//go:embed static` above an `embed.FS` variable embeds the entire directory tree; `fs.WalkDir` walks it exactly like it would a real directory on disk, and `staticFS.ReadFile(path)` reads an individual embedded file's bytes.
+- All three embeds happen at *compile time* — the resulting binary has no dependency on `static/` existing at runtime, unlike [config](../config/)'s `os.Open("config.json")`.
+
+## Common Pitfalls
+
+- **`//go:embed` paths are relative to the source file's directory**, not the working directory at runtime — this is the opposite of `os.Open`, and is what makes the embedded binary portable.
+- **The directive must have no blank line between it and the variable declaration.** A blank line silently turns it into an ordinary comment instead of an embed directive (the build then fails because the variable doesn't have the right embedded content, or fails to compile if the type doesn't match).
+- **Only `string`, `[]byte`, and `embed.FS` are valid embed targets** — no other types.
+- **Map iteration order is randomized by Go on purpose** (`FeatureFlags` here) — never rely on it for output order; sort keys explicitly if deterministic output is required.
+
+## References
+
+- [embed package docs](https://pkg.go.dev/embed)
+- [Go Blog — Go 1.16 embed](https://go.dev/blog/go1.16)
+
+## Next Steps
+
+- [config](../config/) — the same JSON-config idea, but read from disk at runtime instead of embedded
+- [http-server](../http-server/) — pair this with `http.FileServerFS(staticFS)` to serve embedded static assets over HTTP

--- a/examples/embed/go.mod
+++ b/examples/embed/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/embed
+
+go 1.25.0

--- a/examples/embed/main.go
+++ b/examples/embed/main.go
@@ -21,8 +21,8 @@ var configJSON []byte
 var staticFS embed.FS
 
 type appConfig struct {
-	Version      string            `json:"version"`
-	FeatureFlags map[string]bool   `json:"feature_flags"`
+	Version      string          `json:"version"`
+	FeatureFlags map[string]bool `json:"feature_flags"`
 }
 
 func main() {

--- a/go.work
+++ b/go.work
@@ -8,4 +8,5 @@ use (
 	./examples/concurrency/worker-pool
 	./examples/config
 	./examples/context
+	./examples/embed
 )


### PR DESCRIPTION
## Summary
- Migrates `examples/embed` to its own module + full README per `CONTRIBUTING.md`, tagged `basics` / `Beginner`.
- gofmt's `main.go` (pre-existing struct field alignment drift).
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `make run` output matches the documented expected output (feature-flag line order noted as non-deterministic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)