### PR TITLE
Migrate inject to standalone-module standard

### DIFF
--- a/examples/inject/Makefile
+++ b/examples/inject/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/inject/README.md
+++ b/examples/inject/README.md
@@ -1,0 +1,67 @@
+# Inject
+
+**Category:** design-patterns
+**Difficulty:** Beginner
+
+## Objective
+
+Show idiomatic Go dependency injection: passing interfaces into constructors explicitly, with no reflection, struct tags, or DI framework. Contrast with [wire](../wire/), which generates this same wiring at compile time.
+
+## Concepts Covered
+
+- Defining small, consumer-side interfaces (`Namer`, `Planter`) for what a dependency needs to do, not what a concrete type is
+- Constructor functions (`NewNameAPI`, `NewApp`, ...) that accept dependencies as parameters and return a ready-to-use value
+- Composing a dependency graph by hand in `main`, one constructor call at a time
+- Depending on `http.RoundTripper` (an interface) rather than `*http.Client` (a concrete type), so a test could substitute a fake transport
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+inject/
+├── go.mod
+├── main.go
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+Spock is from Vulcan
+```
+
+## Code Walkthrough
+
+- `Namer` and `Planter` are minimal interfaces describing exactly one method each — the shape `App` actually needs, not the shape of any particular implementation.
+- `NameAPI` and `PlanetAPI` are concrete types that happen to satisfy those interfaces; each is constructed via `NewNameAPI`/`NewPlanetAPI`, taking an `http.RoundTripper` (here, `http.DefaultTransport`) as an explicit dependency.
+- `App` depends only on the two interfaces (`names Namer`, `planets Planter`), never on the concrete `*NameAPI`/`*PlanetAPI` types — so a test could hand `NewApp` a fake `Namer`/`Planter` without touching `App`'s code at all.
+- `main` wires the whole graph by hand: construct the leaves first (`nameAPI`, `planetAPI`), then the thing that depends on them (`app`). This is the entire "framework" — there isn't one.
+
+## Common Pitfalls
+
+- **Depending on concrete types instead of interfaces.** If `App` held `*NameAPI` directly, it could never be tested without a real (or heavily mocked) `NameAPI` — depending on `Namer` instead means any type satisfying that one-method interface works.
+- **Defining interfaces on the producer side.** `Namer`/`Planter` are declared where they're *used* (by `App`), not where they're *implemented* (`NameAPI`/`PlanetAPI`) — this is idiomatic Go and keeps interfaces minimal and consumer-driven.
+- **Reaching for a DI framework or reflection-based container before outgrowing manual wiring.** Manual constructor injection, as shown here, scales fine until the dependency graph gets large or repetitive enough that generating the wiring (see [wire](../wire/)) starts paying for itself.
+- **Interfaces with more methods than a consumer needs.** Keep interfaces as small as the consumer requires (`Namer` has exactly one method) rather than mirroring a large concrete type's full method set.
+
+## References
+
+- [Effective Go — Interfaces](https://go.dev/doc/effective_go#interfaces)
+- [Go Proverbs — "The bigger the interface, the weaker the abstraction"](https://go-proverbs.github.io/)
+
+## Next Steps
+
+- [wire](../wire/) — the same dependency graph, wired at compile time by code generation instead of by hand
+- [functional-options](../functional-options/) — a complementary pattern for configuring one of these constructed types

--- a/examples/inject/go.mod
+++ b/examples/inject/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/inject
+
+go 1.25.0

--- a/go.work
+++ b/go.work
@@ -15,4 +15,5 @@ use (
 	./examples/generics
 	./examples/http-client
 	./examples/http-server
+	./examples/inject
 )


### PR DESCRIPTION
## Summary
- Migrates `examples/inject` to its own module + full README per `CONTRIBUTING.md`, tagged `design-patterns` / `Beginner`.
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `make run` output matches the documented expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)