### PR TITLE
Migrate oop to standalone-module standard

### DIFF
--- a/examples/oop/Makefile
+++ b/examples/oop/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/oop/README.md
+++ b/examples/oop/README.md
@@ -1,0 +1,71 @@
+# OOP: Methods, Interfaces, and Polymorphism
+
+**Category:** basics
+**Difficulty:** Beginner
+
+## Objective
+
+Show how Go covers the common "OOP" patterns without classes or inheritance: methods on structs, and runtime polymorphism through interfaces. See [oop/composition](composition/) for struct embedding, Go's alternative to inheritance.
+
+## Concepts Covered
+
+- Declaring methods on a value receiver (`func (r Rect) Area() float64`)
+- Defining a small interface (`Shape`) describing behavior, not implementation
+- Polymorphism: a `[]Shape` holding different concrete types (`Rect`, `Circle`), each satisfying the interface independently
+- `%T` in `fmt.Printf` to print a value's dynamic (concrete) type
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+oop/
+├── go.mod
+├── main.go
+├── composition/
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+main.Rect — area: 50.00, perimeter: 30.00
+main.Circle — area: 153.94, perimeter: 43.98
+```
+
+## Code Walkthrough
+
+- `Shape` declares two methods, `Area()` and `Perimeter()`, with no mention of which types implement it — in Go, a type satisfies an interface simply by having matching methods, with no explicit `implements` declaration.
+- `Rect` and `Circle` are unrelated structs, each with their own `Area`/`Perimeter` implementations — there's no shared base type or inheritance between them.
+- `printShape(s Shape)` accepts anything satisfying `Shape` and calls its methods through the interface — it has no idea, at compile time, whether it's holding a `Rect` or a `Circle`.
+- `main` builds a `[]Shape` mixing both concrete types; ranging over it and calling `printShape` on each demonstrates runtime polymorphism — the correct `Area`/`Perimeter` implementation is dispatched based on each value's actual (dynamic) type.
+- `%T` in the format string prints that dynamic type (`main.Rect`, `main.Circle`), which is otherwise invisible once a value is boxed into the `Shape` interface.
+
+## Common Pitfalls
+
+- **Looking for `class`/`extends`/`implements` keywords.** Go has none — behavior comes from methods on any type, and interface satisfaction is structural (implicit), not declared.
+- **Defining a fat interface with many methods "just in case."** `Shape` has exactly the two methods `printShape` needs — see [inject](../inject/) for more on why small, consumer-defined interfaces are idiomatic.
+- **Choosing a pointer receiver vs. value receiver inconsistently.** `Rect`/`Circle` use value receivers here because they don't need to mutate their fields; a type mixing value and pointer receivers across its methods can fail to satisfy an interface in surprising ways (a value doesn't automatically satisfy an interface requiring a pointer-receiver method).
+- **Expecting inheritance-style code reuse.** There's no `Rect extends Shape` — shared behavior across types in Go usually comes from either interfaces (behavioral contract) or struct embedding (see [composition](composition/), field/method reuse).
+
+## References
+
+- [Effective Go — Interfaces and other types](https://go.dev/doc/effective_go#interfaces_and_types)
+- [Go Tour — Methods and interfaces](https://go.dev/tour/methods/1)
+- [Go Proverbs — "The bigger the interface, the weaker the abstraction"](https://go-proverbs.github.io/)
+
+## Next Steps
+
+- [oop/composition](composition/) — struct embedding as Go's alternative to inheritance
+- [inject](../inject/) — consumer-defined interfaces used for dependency injection

--- a/examples/oop/go.mod
+++ b/examples/oop/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/oop
+
+go 1.25.0

--- a/go.work
+++ b/go.work
@@ -17,4 +17,5 @@ use (
 	./examples/http-server
 	./examples/inject
 	./examples/iterator
+	./examples/oop
 )


### PR DESCRIPTION
## Summary
- Migrates `examples/oop` to its own module + full README per `CONTRIBUTING.md`, tagged `basics` / `Beginner`.
- `examples/oop/composition` is a separate example and isn't part of this module's go.mod scope conceptually; it currently builds as a subpackage of this module only until it gets its own go.mod in the next migration (Go module boundaries nest, so that will automatically carve it back out).
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `make run` output matches the documented expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)