### PR TITLE
Add EXAMPLE=-scoped Makefile targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,34 @@ go test -run TestName ./examples/<name>/... # run a single test
 go test -fuzz=FuzzAdd ./examples/testing-patterns/   # fuzz test (runs until interrupted)
 ```
 
+## Running commands (IMPORTANT)
+
+This is a Go multi-module workspace. All commands run from the repo root.
+
+- NEVER chain commands with `cd`. Do not run compound commands like
+  `cd examples/foo && go build ...`. Multiple directory changes in one
+  command trigger a permission prompt and cannot be persisted to the
+  allowlist. Run each step from the repo root instead.
+- Use the Makefile targets for validation — never raw chained `go`
+  commands. Run them as separate steps, one per line:
+  - `make build`
+  - `make vet`
+  - `make test`
+  - `make lint`
+  - `make fmt`
+- To scope any check to a single example, pass `EXAMPLE=<short-name>`:
+  `make build EXAMPLE=http-server` (omit `EXAMPLE` to run across the
+  whole workspace). This matches the existing `make run EXAMPLE=` convention.
+- Registering a NEW example is a one-time step: `make use EXAMPLE=<name>`
+  (wraps `go work use`). It is committed to `go.work` and must NOT be
+  repeated on every check.
+- `make check EXAMPLE=<name>` runs build + vet + test + lint + fmt for one
+  example in a single command.
+
+### Validating an example (canonical flow)
+New example → `make use EXAMPLE=<name>` (once), then
+`make check EXAMPLE=<name>`.
+
 ### CI enforces build, tidy, lint, and vulnerabilities — not just build/test
 
 `.github/workflows/build.yml` runs four independent jobs on push/PR to `master` (Go 1.24 + 1.25 matrix for the test job only):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,8 @@ New examples are standalone Go modules, isolated from every other example and fr
 
 1. Create a directory under `examples/` with a lowercase, hyphen-separated name, then init its own module and register it with the workspace:
    ```bash
-   mkdir examples/my-topic
-   cd examples/my-topic
-   go mod init github.com/adnvilla/go-examples/examples/my-topic
-   cd ../..
-   go work use ./examples/my-topic
+   mkdir -p examples/my-topic && (cd examples/my-topic && go mod init github.com/adnvilla/go-examples/examples/my-topic)
+   make use EXAMPLE=my-topic
    ```
 
 2. One example = one primary concept (e.g. "Worker Pool", "Circuit Breaker", "Graceful Shutdown"). Don't combine unrelated concepts (e.g. Kafka + Postgres + retry + worker pool) into a single example — split into separate directories instead.

--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,84 @@
 SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
+# If EXAMPLE is set, operate on that single example only (short name, e.g. EXAMPLE=http-server);
+# otherwise operate on every workspace module.
+# Usage: make build EXAMPLE=http-server   (omit EXAMPLE to run across the whole workspace)
+MODULES := $(if $(EXAMPLE),examples/$(EXAMPLE),$(shell go list -m -f '{{.Dir}}'))
+
 ## help: print this help message
 .PHONY: help
 help:
 	@echo "Usage:"
 	@sed -n 's/^##//p' ${MAKEFILE_LIST} | column -t -s ':' | sed -e 's/^/ /'
 
-## build: compile every workspace module (root + each migrated example)
+## build: compile every workspace module, or one with EXAMPLE= (root + each migrated example)
 .PHONY: build
 build:
-	@for d in $$(go list -m -f '{{.Dir}}'); do \
+	@for d in $(MODULES); do \
 		echo "==> build $$d"; \
 		(cd "$$d" && go build ./...) || exit 1; \
 	done
 
-## test: run all tests with the race detector, in every workspace module
+## test: run all tests with the race detector; every module, or one with EXAMPLE=
 .PHONY: test
 test:
-	@for d in $$(go list -m -f '{{.Dir}}'); do \
+	@for d in $(MODULES); do \
 		echo "==> test $$d"; \
 		(cd "$$d" && go test -race -count=1 ./...) || exit 1; \
 	done
 
-## vet: run go vet in every workspace module
+## vet: run go vet; every module, or one with EXAMPLE=
 .PHONY: vet
 vet:
-	@for d in $$(go list -m -f '{{.Dir}}'); do \
+	@for d in $(MODULES); do \
 		echo "==> vet $$d"; \
 		(cd "$$d" && go vet ./...) || exit 1; \
 	done
 
-## lint: run golangci-lint in every workspace module (requires golangci-lint in PATH)
+## fmt: check formatting with gofmt; every module, or one with EXAMPLE=
+.PHONY: fmt
+fmt:
+	@for d in $(MODULES); do \
+		echo "==> fmt $$d"; \
+		out="$$(gofmt -l "$$d")"; \
+		if [ -n "$$out" ]; then echo "$$out"; echo "gofmt: files need formatting"; exit 1; fi; \
+	done
+
+## lint: run golangci-lint; every module, or one with EXAMPLE= (requires golangci-lint in PATH)
 .PHONY: lint
 lint:
-	@for d in $$(go list -m -f '{{.Dir}}'); do \
+	@for d in $(MODULES); do \
 		echo "==> lint $$d"; \
 		(cd "$$d" && golangci-lint run --timeout=5m ./...) || exit 1; \
 	done
 
-## vuln: run govulncheck in every workspace module (requires govulncheck in PATH)
+## vuln: run govulncheck; every module, or one with EXAMPLE= (requires govulncheck in PATH)
 .PHONY: vuln
 vuln:
-	@for d in $$(go list -m -f '{{.Dir}}'); do \
+	@for d in $(MODULES); do \
 		echo "==> vuln $$d"; \
 		(cd "$$d" && govulncheck ./...) || exit 1; \
 	done
 
-## tidy: tidy and verify go.mod / go.sum in every workspace module
+## tidy: tidy and verify go.mod / go.sum; every module, or one with EXAMPLE=
 .PHONY: tidy
 tidy:
-	@for d in $$(go list -m -f '{{.Dir}}'); do \
+	@for d in $(MODULES); do \
 		echo "==> tidy $$d"; \
 		(cd "$$d" && go mod tidy && go mod verify) || exit 1; \
 	done
 
-## run: run a specific example  (usage: make run EXAMPLE=context)
+## use: register a new example in the workspace (usage: make use EXAMPLE=http-server)
+.PHONY: use
+use:
+	@if [ -z "$(EXAMPLE)" ]; then \
+		echo "Usage: make use EXAMPLE=<name>  (e.g. make use EXAMPLE=http-server)"; \
+		exit 1; \
+	fi
+	go work use ./examples/$(EXAMPLE)
+
+## run: run a specific example (usage: make run EXAMPLE=context)
 .PHONY: run
 run:
 	@if [ -z "$(EXAMPLE)" ]; then \
@@ -74,6 +97,10 @@ infra-up:
 infra-down:
 	docker compose down
 
-## ci: run the full local CI pipeline (build + vet + test + lint)
+## check: build + vet + test + lint + fmt for one example (usage: make check EXAMPLE=http-server)
+.PHONY: check
+check: build vet test lint fmt
+
+## ci: run the full local CI pipeline across the whole workspace (build + vet + test + lint)
 .PHONY: ci
 ci: build vet test lint


### PR DESCRIPTION
## Summary
- Adds `EXAMPLE=<name>` scoping to `build`/`test`/`vet`/`lint`/`vuln`/`tidy` so a single example can be validated without chaining `cd examples/<name> && go ...` (which was tripping a permission prompt on every compound `cd` command).
- Adds `make use EXAMPLE=<name>` (wraps `go work use`), `make fmt [EXAMPLE=<name>]`, and `make check EXAMPLE=<name>` (build+vet+test+lint+fmt in one step).
- Updates `CLAUDE.md`/`CONTRIBUTING.md` to document this as the canonical per-example validation flow.
- No change in behavior when `EXAMPLE` is omitted — same whole-workspace loop as before.

## Test plan
- [x] `make build`, `make vet`, `make lint`, `make test`, `make check EXAMPLE=channels` all verified locally
- [x] `make build EXAMPLE=channels` scopes correctly; omitting `EXAMPLE` still covers every workspace module

🤖 Generated with [Claude Code](https://claude.com/claude-code)