### PR TITLE
Migrate pool to standalone-module standard

### DIFF
--- a/examples/pool/Makefile
+++ b/examples/pool/Makefile
@@ -1,0 +1,24 @@
+## run: run the runnable example (this is a library package with no main — its tests are the demonstration)
+.PHONY: run
+run:
+	go test -v ./...
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/pool/README.md
+++ b/examples/pool/README.md
@@ -1,0 +1,80 @@
+# Pool
+
+**Category:** concurrency
+**Difficulty:** Intermediate
+
+## Objective
+
+Show a small, reusable worker-pool package with per-task error tracking: run a fixed number of `func() error` tasks at a configured concurrency, and check afterward which (if any) failed — without any task's error aborting the others.
+
+## Concepts Covered
+
+- A `Task` wrapping a `func() error`, recording its own result (`Err`) after running
+- A `Pool` distributing `*Task` values to a fixed number of worker goroutines over a channel
+- `sync.WaitGroup` to know when every task has finished, regardless of success/failure
+- `HasErrors()` / per-task `Err` fields as a way to inspect partial failure after a batch completes, instead of stopping at the first error (contrast with [errgroup](../errgroup/), which stops early on first failure)
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+pool/
+├── go.mod
+├── pool.go
+├── pool_test.go
+└── README.md
+```
+
+## How to Run
+
+This is a library package (`package pool`), not a `main` package — there's nothing to `go run`. Its tests are the runnable demonstration:
+
+```bash
+make run
+# or
+go test -v ./...
+```
+
+## Expected Output
+
+```
+=== RUN   TestEmptyPool
+2026/07/05 16:42:57 Running 0 task(s) at concurrency 10.
+--- PASS: TestEmptyPool (0.00s)
+=== RUN   TestWithWork
+2026/07/05 16:42:57 Running 3 task(s) at concurrency 10.
+--- PASS: TestWithWork (0.00s)
+=== RUN   TestWithError
+2026/07/05 16:42:57 Running 3 task(s) at concurrency 10.
+--- PASS: TestWithError (0.00s)
+PASS
+```
+
+## Code Walkthrough
+
+- `Task` wraps a `func() error` (`f`) and an `Err` field that's populated once `Run` executes it — `Err` is meaningless until the pool has actually run the task.
+- `Pool.Run` starts `concurrency` worker goroutines (each running `p.work()`, which loops `for task := range p.tasksChan`), then feeds every task into `tasksChan`, closes it once all are sent, and blocks on `wg.Wait()`.
+- Each worker's `task.Run(&p.wg)` executes the task's function, stores the result in `Err`, and calls `wg.Done()` — a failing task doesn't stop other tasks or workers; it just records its own error and moves on.
+- `HasErrors()` scans every task's `Err` field after `Run()` returns, so a caller can check for *any* failure across the whole batch, and (since `Tasks` and each `Task.Err` remain accessible) inspect exactly which ones failed.
+- `TestEmptyPool` confirms a pool with zero tasks runs cleanly; `TestWithWork` confirms all-success; `TestWithError` confirms one failing task among three doesn't prevent the others from completing, and is correctly reported by both `HasErrors()` and the per-task `Err`.
+
+## Common Pitfalls
+
+- **Expecting `Run()` to stop early on the first error**, like [errgroup](../errgroup/) does. This pool always runs every task to completion — if fail-fast behavior is needed instead, `errgroup.Group` is the better fit.
+- **Reading a `Task.Err` before `Pool.Run()` has completed.** `Err` is only meaningful after `Run()` returns; reading it earlier just sees a stale zero value.
+- **Setting `concurrency` higher than the number of tasks provides no benefit** — extra workers just block forever on the (now-closed) `tasksChan` once all tasks are consumed, which is harmless but wasteful.
+- **Reusing a `Pool` for a second `Run()` call.** `tasksChan` is closed at the end of the first `Run()`; a fresh `Pool` (via `NewPool`) is needed for another batch.
+
+## References
+
+- [sync package docs — WaitGroup](https://pkg.go.dev/sync#WaitGroup)
+- [Go by Example — Worker Pools](https://gobyexample.com/worker-pools)
+
+## Next Steps
+
+- [concurrency/worker-pool](../concurrency/worker-pool/) — the same fixed-pool shape as a runnable `main` example
+- [errgroup](../errgroup/) — the fail-fast alternative, stopping on the first error instead of collecting all of them

--- a/examples/pool/go.mod
+++ b/examples/pool/go.mod
@@ -1,0 +1,11 @@
+module github.com/adnvilla/go-examples/examples/pool
+
+go 1.25.0
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/examples/pool/go.sum
+++ b/examples/pool/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golang/protobuf v1.5.4
 	github.com/redis/go-redis/v9 v9.21.0
-	github.com/stretchr/testify v1.9.0
 )
 
 require (
@@ -21,7 +20,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
 	github.com/cloudwego/iasm v0.2.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -37,7 +35,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.work
+++ b/go.work
@@ -22,6 +22,7 @@ use (
 	./examples/iterator
 	./examples/oop
 	./examples/oop/composition
+	./examples/pool
 	./examples/profiling
 	./examples/recover
 	./examples/reflection-bench


### PR DESCRIPTION
## Summary
- Migrates `examples/pool` to its own module + full README per `CONTRIBUTING.md`, tagged `concurrency` / `Intermediate`.
- Also tidies root `go.mod`: `pool` was the last remaining user of `stretchr/testify` in the root module (after `serialization` and `reflection-bench` were already migrated), so `go mod tidy` drops it entirely from root.
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `go build ./...` verified at root after the tidy cleanup
- [x] `go test -v ./...` output matches the documented expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)