### PR TITLE
Migrate metric to standalone-module standard

### DIFF
--- a/examples/metric/Makefile
+++ b/examples/metric/Makefile
@@ -1,0 +1,24 @@
+## run: run the example (sends a metric every second, forever — Ctrl+C to stop)
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/metric/README.md
+++ b/examples/metric/README.md
@@ -1,0 +1,77 @@
+# Metric
+
+**Category:** observability
+**Difficulty:** Beginner
+
+## Objective
+
+Show sending a counter metric to StatsD/Datadog via `github.com/DataDog/datadog-go/statsd` — the client-side half of a metrics pipeline, independent of whether anything is actually listening.
+
+## Concepts Covered
+
+- `statsd.New(addr)` — constructs a UDP client; since UDP is connectionless, this succeeds even if nothing is listening at `addr`
+- `statsd.Count(name, value, tags, rate)` — increments a counter metric, with tags for dimensional filtering (`service:go-examples` here) and a sample rate
+- Why sending metrics over UDP is fire-and-forget: a missing or unreachable collector doesn't produce an error, since there's no delivery acknowledgment at the protocol level
+
+## Prerequisites
+
+- Go 1.24+
+- Optional: a StatsD-compatible listener on `127.0.0.1:8125` to actually see the metrics land somewhere (this repo's `docker-compose.yml` provides one):
+  ```bash
+  docker compose up -d statsd
+  ```
+  Without it, the program still runs — the metric packets are just silently dropped since UDP has no delivery confirmation.
+
+## Project Structure
+
+```
+metric/
+├── go.mod
+├── main.go
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+Runs forever, sending one `example_metric.histogram` count every second — stop it with `Ctrl+C`.
+
+## Expected Output
+
+```
+2026/07/05 17:13:27 Done...
+2026/07/05 17:13:28 Done...
+2026/07/05 17:13:29 Done...
+```
+
+(Identical whether or not a StatsD listener is actually running at `127.0.0.1:8125` — the client has no way to know.)
+
+## Code Walkthrough
+
+- `statsd.New("127.0.0.1:8125")` creates the client. It doesn't perform any network handshake — UDP is connectionless, so "connecting" is really just recording the destination address.
+- `statsd.Count("example_metric.histogram", 1, tags, 1)` sends a counter increment: the metric name, the increment value (`1`), a set of tags (`service:go-examples`), and a sample rate (`1` = 100%, i.e. send every call — a lower value like `0.1` would randomly sample only 10% of calls, useful for high-volume metrics).
+- The loop runs forever, sleeping one second between sends, logging `"Done..."` regardless of whether the send actually reached a collector.
+- `err := statsd.Count(...)` is checked and logged if non-nil — but a `nil` error here only means the client successfully *handed the packet to the OS* for sending, not that any collector received it.
+
+## Common Pitfalls
+
+- **Treating a `nil` error from `Count` as delivery confirmation.** UDP has no acknowledgment; a `nil` error just means the local send call succeeded, not that anything downstream received the metric.
+- **Using sample rate `1` for very high-frequency metrics in production.** At high call volumes, sampling (e.g. `0.1`) reduces network/collector load — the client-side library scales the reported value accordingly so aggregate counts remain statistically correct.
+- **Forgetting tags entirely.** Without tags like `service:go-examples`, metrics from different services/environments become indistinguishable once aggregated centrally.
+- **Assuming this needs the docker-compose `statsd` service to run at all.** It doesn't — the point of this example is precisely that the client behaves identically whether or not a listener exists; only if you want to *see* the metrics land somewhere does the service matter.
+
+## References
+
+- [DataDog/datadog-go GitHub repository](https://github.com/DataDog/datadog-go)
+- [StatsD protocol](https://github.com/statsd/statsd/blob/master/docs/metric_types.md)
+- [Datadog — DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/)
+
+## Next Steps
+
+- [slog](../slog/) — structured logging, the complementary observability signal to metrics
+- [profiling](../profiling/) — CPU profiling, another way of measuring what a program is doing

--- a/examples/metric/go.mod
+++ b/examples/metric/go.mod
@@ -1,0 +1,11 @@
+module github.com/adnvilla/go-examples/examples/metric
+
+go 1.25.0
+
+require github.com/DataDog/datadog-go v4.8.3+incompatible
+
+require (
+	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
+	golang.org/x/sys v0.10.0 // indirect
+)

--- a/examples/metric/go.sum
+++ b/examples/metric/go.sum
@@ -1,0 +1,16 @@
+github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
+github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
+golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/adnvilla/go-examples
 go 1.25.0
 
 require (
-	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/aws/aws-lambda-go v1.47.0
 	github.com/aws/aws-sdk-go v1.54.0
 	github.com/gin-gonic/gin v1.10.0
@@ -13,7 +12,6 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
-github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
-github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1sXVI=
 github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go v1.54.0 h1:tGCQ6YS2TepzKtbl+ddXnLIoV8XvWdxMKtuMxdrsa4U=
@@ -74,7 +70,6 @@ github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3b
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/go.work
+++ b/go.work
@@ -20,6 +20,7 @@ use (
 	./examples/http-server
 	./examples/inject
 	./examples/iterator
+	./examples/metric
 	./examples/oop
 	./examples/oop/composition
 	./examples/pool


### PR DESCRIPTION
## Summary
- Migrates `examples/metric` to its own module + full README per `CONTRIBUTING.md`, tagged `observability` / `Beginner`.
- Documents that the example runs identically with or without the docker-compose `statsd` service — UDP delivery has no acknowledgment, so a missing collector is invisible to the client.
- Also tidies root `go.mod`: `metric` was the only user of `DataDog/datadog-go` in root.
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `go build ./...` verified at root after the tidy cleanup
- [x] Ran the built binary for a few seconds without a statsd listener running, confirmed no error/crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)