### PR TITLE
Migrate lambda to standalone-module standard

### DIFF
--- a/examples/lambda/Makefile
+++ b/examples/lambda/Makefile
@@ -1,0 +1,31 @@
+## run: attempt to run the handler locally — fails fast with a clear error (see README); this is expected
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)
+
+## build-lambda: cross-compile for AWS Lambda's runtime (linux/amd64)
+.PHONY: build-lambda
+build-lambda:
+	GOOS=linux GOARCH=amd64 go build -o bootstrap .
+	zip main.zip bootstrap
+	rm bootstrap

--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -1,39 +1,78 @@
-# Go Lambda
+# Lambda
 
+**Category:** cloud
+**Difficulty:** Beginner
 
-```go
-// main.go
-package main
+## Objective
 
-import (
-	"github.com/aws/aws-lambda-go/lambda"
-)
+Show the minimal shape of an AWS Lambda function written in Go: a handler function matching one of `aws-lambda-go`'s supported signatures, registered with `lambda.Start`, plus reading configuration from a Lambda environment variable.
 
-func hello() (string, error) {
-	return "Hello ƛ!", nil
-}
+## Concepts Covered
 
-func main() {
-	// Make the handler available for Remote Procedure Call by AWS Lambda
-	lambda.Start(hello)
-}
+- `lambda.Start(handlerFunc)` — hands control to the Lambda runtime, which invokes `handlerFunc` once per incoming event
+- A handler with signature `func() (string, error)` — one of several signatures `aws-lambda-go` supports (others take an event/context parameter)
+- Reading a Lambda-configured environment variable (`os.Getenv("V1")`) — how Lambda functions typically receive configuration, since there's no CLI or config file at invocation time
+- Why this program fails immediately when run outside an actual Lambda environment (see Expected Output)
+
+## Prerequisites
+
+- Go 1.24+
+- No external services needed to **build** the example
+- Actually **invoking** it requires either deploying to AWS Lambda, or a local Lambda emulator (e.g. the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)); an AWS account/credentials are needed to deploy
+
+## Project Structure
+
+```
+lambda/
+├── go.mod
+├── main.go
+└── README.md
 ```
 
-    go.exe get -u github.com/aws/aws-lambda-go/cmd/build-lambda-zip
-    set GOOS=linux
-    set GOARCH=amd64
-    go build -o main main.go
-    %USERPROFILE%\Go\bin\build-lambda-zip.exe -o main.zip main
+## How to Run
 
+Running it directly (`go run .` / `make run`) is expected to fail — see Expected Output. To actually deploy it to Lambda:
 
+```bash
+make build-lambda   # cross-compiles for linux/amd64 and produces main.zip
+```
 
+Then upload `main.zip` to a Lambda function using the `provided.al2` or `provided.al2023` custom runtime (Go's dedicated `go1.x` managed runtime has been deprecated by AWS in favor of this), with the handler set to `bootstrap`.
 
-# Resources
+## Expected Output
 
-https://docs.aws.amazon.com/es_es/lambda/latest/dg/go-programming-model-context.html
+Running the binary directly, outside a real Lambda environment:
+```
+2026/07/05 17:33:12 expected AWS Lambda environment variables [_LAMBDA_SERVER_PORT AWS_LAMBDA_RUNTIME_API] are not defined
+```
 
-https://docs.aws.amazon.com/es_es/lambda/latest/dg/best-practices.html
+This is `lambda.Start` correctly detecting it isn't running inside the Lambda runtime, and failing fast rather than hanging. Once actually deployed and invoked (with `V1=some-value` set as a Lambda environment variable), the handler returns:
+```
+Hello ƛ! some-value
+```
 
-https://docs.aws.amazon.com/es_es/lambda/latest/dg/go-programming-model-env-variables.html
+## Code Walkthrough
 
-https://github.com/aws/aws-lambda-go
+- `hello() (string, error)` is the handler — it takes no event parameter (a valid `aws-lambda-go` handler signature for functions that don't need input), reads the `V1` environment variable, and returns a greeting string plus a `nil` error.
+- `lambda.Start(hello)` is the entire `main` function's job: register `hello` and hand control to the Lambda runtime's event loop. `lambda.Start` never returns under normal operation inside Lambda — it blocks, waiting for and dispatching invocations for the lifetime of the execution environment.
+- Outside Lambda, `lambda.Start` checks for the environment variables the real runtime always sets (`AWS_LAMBDA_RUNTIME_API`, `_LAMBDA_SERVER_PORT`) and exits immediately with an error if they're missing — which is what running this locally demonstrates.
+- Configuration via environment variable (`V1`) is the standard way Lambda functions receive settings, since there's no command line or config file involved in an invocation.
+
+## Common Pitfalls
+
+- **Expecting `go run .` to actually invoke the handler locally.** It can't — there's no Lambda runtime API to talk to outside AWS (or a local emulator like SAM CLI). The clear failure message is a feature, not a bug.
+- **Naming the compiled binary anything other than `bootstrap` for the `provided.al2`/`provided.al2023` runtimes.** These custom runtimes specifically look for an executable named `bootstrap` in the deployment package; the older `go1.x` managed runtime (deprecated) used different conventions (e.g. a binary named `main`).
+- **Forgetting to cross-compile.** Lambda runs on Linux/amd64 (or arm64) regardless of what OS you develop on — `GOOS=linux GOARCH=amd64 go build` (as `make build-lambda` does) is required when building from macOS or Windows.
+- **Assuming the handler must take an event parameter.** `aws-lambda-go` supports handlers with zero, one, or two parameters (event and/or `context.Context`) — a zero-parameter handler like `hello` is valid when the function doesn't need any input.
+
+## References
+
+- [aws-lambda-go GitHub repository](https://github.com/aws/aws-lambda-go)
+- [AWS Lambda — Building Lambda functions with Go](https://docs.aws.amazon.com/lambda/latest/dg/lambda-golang.html)
+- [AWS Lambda — Handler function signatures](https://docs.aws.amazon.com/lambda/latest/dg/golang-handler.html)
+- [AWS Lambda — Environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
+
+## Next Steps
+
+- [http-server](../http-server/) — a "regular" long-running server, for contrast with Lambda's per-invocation execution model
+- [config](../config/) — an alternative configuration source (a file) instead of environment variables

--- a/examples/lambda/go.mod
+++ b/examples/lambda/go.mod
@@ -1,0 +1,5 @@
+module github.com/adnvilla/go-examples/examples/lambda
+
+go 1.25.0
+
+require github.com/aws/aws-lambda-go v1.54.0

--- a/examples/lambda/go.sum
+++ b/examples/lambda/go.sum
@@ -1,0 +1,10 @@
+github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
+github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/adnvilla/go-examples
 go 1.25.0
 
 require (
-	github.com/aws/aws-lambda-go v1.47.0
 	github.com/aws/aws-sdk-go v1.54.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-sql-driver/mysql v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1sXVI=
-github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go v1.54.0 h1:tGCQ6YS2TepzKtbl+ddXnLIoV8XvWdxMKtuMxdrsa4U=
 github.com/aws/aws-sdk-go v1.54.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=

--- a/go.work
+++ b/go.work
@@ -20,6 +20,7 @@ use (
 	./examples/http-server
 	./examples/inject
 	./examples/iterator
+	./examples/lambda
 	./examples/metric
 	./examples/oop
 	./examples/oop/composition


### PR DESCRIPTION
## Summary
- Migrates `examples/lambda` to its own module + full README per `CONTRIBUTING.md`, tagged `cloud` / `Beginner`.
- Documents that `lambda.Start` fails fast with a clear error when run outside a real Lambda runtime (verified locally).
- Updates the packaging instructions to the current `provided.al2`/`provided.al2023` custom-runtime convention (binary named `bootstrap`), since the old `go1.x` managed runtime the original README referenced has been deprecated by AWS.
- Also tidies root `go.mod`: `lambda` was the only user of `aws-lambda-go` in root.
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module
- [x] `go build ./...` verified at root after the tidy cleanup
- [x] Ran the built binary locally and confirmed the documented "missing Lambda environment variables" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)