### PR TITLE
Migrate mysql to standalone-module standard

### DIFF
--- a/examples/mysql/Makefile
+++ b/examples/mysql/Makefile
@@ -1,0 +1,29 @@
+## run: run the example (requires MySQL — see infra-up)
+.PHONY: run
+run:
+	go run .
+
+## infra-up: start the MySQL service this example needs (run from the repo root's docker-compose.yml)
+.PHONY: infra-up
+infra-up:
+	docker compose -f ../../docker-compose.yml up -d mysql
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -1,0 +1,74 @@
+# MySQL
+
+**Category:** database
+**Difficulty:** Beginner
+
+## Objective
+
+Show the basic `database/sql` + `go-sql-driver/mysql` pattern: connect, prepare statements once and reuse them, insert rows, and query a single value back with `Scan`.
+
+## Concepts Covered
+
+- `sql.Open` with the MySQL driver registered via blank import (`_ "github.com/go-sql-driver/mysql"`)
+- `db.Prepare` — compiling a statement once and reusing it across many `Exec`/`QueryRow` calls, rather than re-parsing SQL on every call
+- `stmtOut.QueryRow(...).Scan(&dest)` — the standard pattern for fetching a single row into Go variables
+- Why this file predates `context` in `database/sql`'s API — see Common Pitfalls (same reasoning as [benchmark](../benchmark/))
+
+## Prerequisites
+
+- Go 1.24+
+- A running MySQL instance matching this repo's `docker-compose.yml` (`root`/`secret`@`localhost:3306`/`examples`):
+  ```bash
+  docker compose up -d mysql
+  # or, from this directory:
+  make infra-up
+  ```
+
+## Project Structure
+
+```
+mysql/
+├── go.mod
+├── main.go
+└── README.md
+```
+
+## How to Run
+
+```bash
+make infra-up   # start MySQL
+make run
+```
+
+## Expected Output
+
+```
+The square number of 13 is: 169
+The square number of 1 is: 1
+```
+
+## Code Walkthrough
+
+- `main` connects to MySQL, then unconditionally `DROP TABLE IF EXISTS` + `CREATE TABLE squareNum (number INT PRIMARY KEY, squareNumber INT)` — this makes the example self-contained and repeatable: it never depends on a table having been created by some other process beforehand, and running it twice in a row doesn't fail on duplicate keys.
+- `stmtIns` is a prepared `INSERT` statement, reused inside a loop that inserts 25 rows (`number = i`, `squareNumber = i*i` for `i` in `0..24`) — preparing once and executing many times avoids re-parsing the SQL for every insert.
+- `stmtOut` is a prepared `SELECT` statement with one placeholder (`number = ?`); it's reused for both lookups (`13` and `1`) in the same way.
+- `stmtOut.QueryRow(13).Scan(&squareNum)` runs the query, expects exactly one result row, and copies its single column into `squareNum` — `Scan` is how `database/sql` converts a driver-level row into Go types.
+
+## Common Pitfalls
+
+- **This file predates `context.Context` in `database/sql`.** All calls use the context-less API (`db.Prepare`/`Exec`/`QueryRow` instead of their `...Context` counterparts); it's excluded from `noctx`/`errcheck` linting in `.golangci.yml` for exactly this reason — don't "fix" it to add context plumbing as a drive-by change without also updating the surrounding pattern intentionally.
+- **`Scan` on a query with zero matching rows returns `sql.ErrNoRows`**, not a zero value — always check the error rather than assuming `Scan` populated something.
+- **Forgetting `defer stmt.Close()` on prepared statements.** Each prepared statement holds a server-side resource; not closing it (as this example correctly does via `defer`) leaks it for the lifetime of the connection.
+- **Panicking on every error, as this example does.** Fine for a minimal demo; real code should return errors and let the caller decide how to handle a failed connection or query, per [errors](../errors/).
+- **Running this against a MySQL instance without the `docker-compose` credentials.** The connection string is hardcoded to match this repo's `docker-compose.yml` exactly (`root`/`secret`/`examples` on `localhost:3306`) — pointing it at a different instance requires editing `main.go`.
+
+## References
+
+- [database/sql package docs](https://pkg.go.dev/database/sql)
+- [go-sql-driver/mysql GitHub repository](https://github.com/go-sql-driver/mysql)
+- [Go database/sql tutorial](http://go-database-sql.org/)
+
+## Next Steps
+
+- [benchmark](../benchmark/) — benchmarking `database/sql` connection-pool settings against this same MySQL service
+- [dynamodb](../dynamodb/) — a NoSQL alternative, for comparison

--- a/examples/mysql/go.mod
+++ b/examples/mysql/go.mod
@@ -1,0 +1,7 @@
+module github.com/adnvilla/go-examples/examples/mysql
+
+go 1.25.0
+
+require github.com/go-sql-driver/mysql v1.10.0
+
+require filippo.io/edwards25519 v1.2.0 // indirect

--- a/examples/mysql/go.sum
+++ b/examples/mysql/go.sum
@@ -1,0 +1,4 @@
+filippo.io/edwards25519 v1.2.0 h1:crnVqOiS4jqYleHd9vaKZ+HKtHfllngJIiOpNpoJsjo=
+filippo.io/edwards25519 v1.2.0/go.mod h1:xzAOLCNug/yB62zG1bQ8uziwrIqIuxhctzJT18Q77mc=
+github.com/go-sql-driver/mysql v1.10.0 h1:Q+1LV8DkHJvSYAdR83XzuhDaTykuDx0l6fkXxoWCWfw=
+github.com/go-sql-driver/mysql v1.10.0/go.mod h1:M+cqaI7+xxXGG9swrdeUIoPG3Y3KCkF0pZej+SK+nWk=

--- a/examples/mysql/main.go
+++ b/examples/mysql/main.go
@@ -9,13 +9,20 @@ import (
 )
 
 func main() {
-	// db, err := sql.Open("mysql", "user:password@/database")
-	// db, err := sql.Open("mysql", "user:password@tcp(localhost:5555)/dbname?tls=skip-verify&autocommit=true")
-	db, err := sql.Open("mysql", "id:password@tcp(your-amazonaws-uri.com:3306)/dbname")
+	// Matches this repo's docker-compose mysql service: root/secret@localhost:3306/examples.
+	db, err := sql.Open("mysql", "root:secret@tcp(localhost:3306)/examples")
 	if err != nil {
 		panic(err.Error()) // Just for example purpose. You should use proper error handling instead of panic
 	}
 	defer db.Close()
+
+	// Recreate the table on every run so the example is self-contained and repeatable.
+	if _, err := db.Exec("DROP TABLE IF EXISTS squareNum"); err != nil {
+		panic(err.Error())
+	}
+	if _, err := db.Exec("CREATE TABLE squareNum (number INT PRIMARY KEY, squareNumber INT)"); err != nil {
+		panic(err.Error())
+	}
 
 	// Prepare statement for inserting data
 	stmtIns, err := db.Prepare("INSERT INTO squareNum VALUES( ?, ? )") // ? = placeholder
@@ -25,14 +32,14 @@ func main() {
 	defer stmtIns.Close() // Close the statement when we leave main() / the program terminates
 
 	// Prepare statement for reading data
-	stmtOut, err := db.Prepare("SELECT squareNumber FROM squarenum WHERE number = ?")
+	stmtOut, err := db.Prepare("SELECT squareNumber FROM squareNum WHERE number = ?")
 	if err != nil {
 		panic(err.Error()) // proper error handling instead of panic in your app
 	}
 	defer stmtOut.Close()
 
 	// Insert square numbers for 0-24 in the database
-	for i := 0; i < 25; i++ {
+	for i := range 25 {
 		_, err = stmtIns.Exec(i, (i * i)) // Insert tuples (i, i^2)
 		if err != nil {
 			panic(err.Error()) // proper error handling instead of panic in your app
@@ -46,12 +53,12 @@ func main() {
 	if err != nil {
 		panic(err.Error()) // proper error handling instead of panic in your app
 	}
-	fmt.Printf("The square number of 13 is: %d", squareNum)
+	fmt.Printf("The square number of 13 is: %d\n", squareNum)
 
 	// Query another number.. 1 maybe?
 	err = stmtOut.QueryRow(1).Scan(&squareNum) // WHERE number = 1
 	if err != nil {
 		panic(err.Error()) // proper error handling instead of panic in your app
 	}
-	fmt.Printf("The square number of 1 is: %d", squareNum)
+	fmt.Printf("The square number of 1 is: %d\n", squareNum)
 }

--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,9 @@ module github.com/adnvilla/go-examples
 
 go 1.25.0
 
-require (
-	github.com/aws/aws-sdk-go v1.54.0
-	github.com/go-sql-driver/mysql v1.8.1
-)
+require github.com/aws/aws-sdk-go v1.54.0
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,8 @@
-filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
-filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/aws/aws-sdk-go v1.54.0 h1:tGCQ6YS2TepzKtbl+ddXnLIoV8XvWdxMKtuMxdrsa4U=
 github.com/aws/aws-sdk-go v1.54.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
-github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/go.work
+++ b/go.work
@@ -23,6 +23,7 @@ use (
 	./examples/iterator
 	./examples/lambda
 	./examples/metric
+	./examples/mysql
 	./examples/oop
 	./examples/oop/composition
 	./examples/pool


### PR DESCRIPTION
## Summary
- Migrates `examples/mysql` to its own module + full README per `CONTRIBUTING.md`, tagged `database` / `Beginner`.
- Fixes a real pre-existing bug: the hardcoded DSN pointed at a placeholder AWS host (`your-amazonaws-uri.com`) and never matched this repo's docker-compose mysql service; the example also never created its own `squareNum` table, so it couldn't have run successfully against a fresh docker-compose instance before this fix.
- Now connects to `root:secret@localhost:3306/examples` and recreates the table on every run (`DROP TABLE IF EXISTS` + `CREATE TABLE`), making it self-contained and idempotent — verified by running it twice in a row against the real service.
- Also fixes the inconsistent `squareNum`/`squarenum` table-name casing and missing trailing newlines in the `Printf` output.
- Also tidies root `go.mod`: `mysql` was the only remaining user of `go-sql-driver/mysql` in root — `aws-sdk-go` (for `dynamodb`, the last unmigrated example) is now the only dependency left there.
- Registered in `go.work`.

## Test plan
- [x] `go build/vet/test`, `gofmt -l .`, `golangci-lint run ./...` all pass inside the module (0 issues — confirms the legacy noctx/errcheck exclude-rule still applies)
- [x] `go build ./...` verified at root after the tidy cleanup
- [x] Started the docker-compose `mysql` service, ran the example twice in a row against it — both runs produced the documented output

🤖 Generated with [Claude Code](https://claude.com/claude-code)