### PR TITLE
Fix root README descriptions for reflection-bench and typecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [metric](examples/metric/) | StatsD metrics to Datadog |
 | [profiling](examples/profiling/) | CPU/memory profiling with `pkg/profile` |
 | [benchmark](examples/benchmark/) | Benchmarks with `testing.B` |
-| [reflection-bench](examples/reflection-bench/) | type switch vs type assertion vs interface |
-| [typecast](examples/typecast/) | Benchmark: dispatch strategies compared |
+| [reflection-bench](examples/reflection-bench/) | Benchmark: `reflect`-based slice construction vs plain `append`, with optional pprof profiles |
+| [typecast](examples/typecast/) | Benchmark: dispatch strategies compared (method call, interface, type switch, type assertion) |
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- The root README described `reflection-bench` as "type switch vs type assertion vs interface" — that's `typecast`'s content; `reflection-bench` actually benchmarks `reflect.MakeSlice`/`reflect.Append` slice construction against a plain `append` loop
- Correct that row and expand the `typecast` row to name the four dispatch strategies it compares, so the two entries no longer read as duplicates
- Docs-only; the per-example READMEs already differentiate and cross-reference the two correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)