### PR TITLE
Add io-readers-writers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 
 | Directory | Description |
 |-----------|-------------|
+| [io-readers-writers](examples/io-readers-writers/) | `io.Reader`/`io.Writer` contract and stream combinators (`Copy`, `TeeReader`, `MultiWriter`, `Pipe`) |
 | [config](examples/config/) | Reading JSON config with `encoding/json` |
 | [datetime-parse](examples/datetime-parse/) | Parsing dates in multiple formats |
 | [flags](examples/flags/) | Command-line flags with `flag` |

--- a/examples/io-readers-writers/Makefile
+++ b/examples/io-readers-writers/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/io-readers-writers/README.md
+++ b/examples/io-readers-writers/README.md
@@ -1,0 +1,102 @@
+# io Readers and Writers
+
+**Category:** basics
+**Difficulty:** Beginner
+
+## Objective
+
+Show the `io.Reader`/`io.Writer` contract — the two one-method interfaces that everything byte-shaped in Go flows through (files, sockets, HTTP bodies, gzip, hashes) — and the standard-library combinators that compose them: `io.Copy`, `io.LimitReader`, `bufio.Scanner`, `io.TeeReader`, `io.MultiWriter`, and `io.Pipe`.
+
+## Concepts Covered
+
+- The raw `Read(p []byte) (n int, err error)` contract: caller-owned buffers, partial reads, and why the `n > 0` bytes must be processed *before* checking the error
+- `io.Copy` — moving bytes from any reader to any writer without a hand-written loop
+- `io.LimitReader` — capping how much downstream code can read (e.g. bounding untrusted input)
+- `bufio.Scanner` — buffered, line-oriented consumption of a stream
+- `io.TeeReader` — observing a stream as it's consumed (payload + sha256 checksum in a single pass)
+- `io.MultiWriter` — fanning one write out to several sinks (the writer-side dual of `TeeReader`)
+- `io.Pipe` — connecting writer-shaped code (`json.Encoder`) to reader-shaped code (`io.ReadAll`) across goroutines, and propagating failures with `CloseWithError`
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+io-readers-writers/
+├── go.mod
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+--- manual Read loop (the io.Reader contract) ---
+read 8 bytes: "the quic"
+read 8 bytes: "k brown "
+read 3 bytes: "fox"
+reached EOF
+
+--- io.Copy and io.LimitReader ---
+copied 15 bytes: "streams compose"
+limited copy: "only the "
+
+--- bufio.Scanner (buffered line reading) ---
+line 1: alpha
+line 2: beta
+line 3: gamma
+
+--- io.TeeReader (observe a stream while consuming it) ---
+consumed: "hash me as I stream"
+sha256:   6d62014a7187de5a31e41868d862792782dcd09958f8f79c4c29f9e3657b691d
+
+--- io.MultiWriter (one write, several sinks) ---
+buffer 1: "fan out this write"
+buffer 2: "fan out this write"
+sha256:   810f3c31e3e431437aaf5e1a2521178bf406656678d029ae3d972c7991990156
+
+--- io.Pipe (connect writer-shaped code to reader-shaped code) ---
+received: {"name":"ping","seq":1}
+```
+
+## Code Walkthrough
+
+- `readInChunks` drives a `strings.Reader` by hand with an 8-byte buffer: each `Read` fills as much of the buffer as it can and reports `n`; the final call returns the leftover 3 bytes, and the one after that returns `0, io.EOF`. The loop's shape — *use the `n` bytes first, then check the error* — is the part that matters: a reader is allowed to return data and `io.EOF` in the same call.
+- `copyStreams` replaces that loop with `io.Copy`, which works for any reader/writer pair and returns the byte count. Wrapping the source in `io.LimitReader(r, 9)` makes the copy stop after 9 bytes — the standard way to bound how much you'll accept from an untrusted stream.
+- `bufferedLines` shows why you rarely call `Read` directly for text: `bufio.Scanner` buffers the underlying reader and hands you whole lines. Its errors surface via `scanner.Err()` *after* the loop, not per-iteration.
+- `teeWhileReading` computes a checksum without a second pass: `io.TeeReader(src, hasher)` copies every byte that flows through it into the hash writer, so `io.ReadAll` yields the payload and the hasher ends up with the digest simultaneously — the same trick used to hash an upload while saving it to disk.
+- `writeOnceToMany` is the mirror image: `io.MultiWriter` returns a writer that duplicates each `Write` into every sink (two buffers and a hash here — identical content, and the digest differs from the previous demo only because the payload does).
+- `pipeAcrossGoroutines` bridges an API that *wants a writer* (`json.NewEncoder(w).Encode`) with one that *wants a reader* (`io.ReadAll`) using `io.Pipe`, no intermediate buffer. Each `Write` blocks until the other side `Read`s, which is why the encoder runs in its own goroutine; `CloseWithError` forwards any encoding failure to the reading side (with `nil` it's a normal close).
+
+## Common Pitfalls
+
+- **Checking the error before consuming the bytes.** `Read` can return `n > 0` *and* `io.EOF` together — handling the error first silently drops the final chunk of the stream. This is the most common misuse of the interface.
+- **Assuming `Read` fills the buffer.** A reader may return fewer bytes than requested at any time, not just at the end (network readers do this constantly). If you need exactly `len(buf)` bytes, use `io.ReadFull`, not a single `Read`.
+- **Using `io.Pipe` from one goroutine.** Writes block until matched by reads, so writing and then reading sequentially in the same goroutine deadlocks. If you don't need streaming, a `bytes.Buffer` is the simpler tool — it's a non-blocking reader *and* writer.
+- **Forgetting `scanner.Err()`.** `Scan` returning `false` means *stopped*, not necessarily *finished* — the loop looks identical for EOF and for a read error. `bufio.Scanner` also silently stops at lines longer than 64 KiB unless you raise the limit with `scanner.Buffer`.
+- **`io.ReadAll` on unbounded input.** It buffers everything in memory; for large or untrusted streams, prefer `io.Copy` into a bounded destination or wrap the source in `io.LimitReader` first.
+
+## References
+
+- [io package docs](https://pkg.go.dev/io)
+- [bufio package docs](https://pkg.go.dev/bufio)
+- [io package docs — Pipe](https://pkg.go.dev/io#Pipe)
+- [Effective Go — Interfaces](https://go.dev/doc/effective_go#interfaces)
+
+## Next Steps
+
+- [http-client](../http-client/) — response bodies are `io.ReadCloser`s; the contract shown here is why they must be drained and closed
+- [embed](../embed/) — embedded files expose the same `io/fs` reader interfaces
+- [serialization](../serialization/) — `encoding/json` works over these same reader/writer seams

--- a/examples/io-readers-writers/go.mod
+++ b/examples/io-readers-writers/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/io-readers-writers
+
+go 1.25.0

--- a/examples/io-readers-writers/main.go
+++ b/examples/io-readers-writers/main.go
@@ -1,0 +1,154 @@
+// Demonstrates the io.Reader/io.Writer contract and the stdlib combinators
+// (io.Copy, io.LimitReader, bufio, io.TeeReader, io.MultiWriter, io.Pipe) that
+// let small stream pieces compose into pipelines without loading everything
+// into memory — the foundation under files, sockets, HTTP bodies, and gzip.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	demos := []func() error{
+		readInChunks,
+		copyStreams,
+		bufferedLines,
+		teeWhileReading,
+		writeOnceToMany,
+		pipeAcrossGoroutines,
+	}
+	for _, demo := range demos {
+		if err := demo(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readInChunks shows the raw io.Reader contract: Read fills a caller-owned
+// buffer, returns how many bytes it wrote, and signals exhaustion with io.EOF.
+// The n > 0 bytes must be processed *before* looking at the error — a reader
+// may return data and io.EOF in the same call.
+func readInChunks() error {
+	fmt.Println("--- manual Read loop (the io.Reader contract) ---")
+	reader := strings.NewReader("the quick brown fox")
+	buf := make([]byte, 8)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			fmt.Printf("read %d bytes: %q\n", n, buf[:n])
+		}
+		if err == io.EOF {
+			fmt.Println("reached EOF")
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// copyStreams moves bytes between a reader and a writer without a hand-written
+// loop; io.LimitReader wraps a reader so downstream code can't read past a cap.
+func copyStreams() error {
+	fmt.Println("\n--- io.Copy and io.LimitReader ---")
+	var dst bytes.Buffer
+	n, err := io.Copy(&dst, strings.NewReader("streams compose"))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("copied %d bytes: %q\n", n, dst.String())
+
+	dst.Reset()
+	limited := io.LimitReader(strings.NewReader("only the first 9 bytes survive"), 9)
+	if _, err := io.Copy(&dst, limited); err != nil {
+		return err
+	}
+	fmt.Printf("limited copy: %q\n", dst.String())
+	return nil
+}
+
+// bufferedLines wraps a reader in bufio.Scanner, which batches small reads and
+// splits the stream into lines — the standard way to consume line-oriented input.
+func bufferedLines() error {
+	fmt.Println("\n--- bufio.Scanner (buffered line reading) ---")
+	scanner := bufio.NewScanner(strings.NewReader("alpha\nbeta\ngamma\n"))
+	line := 1
+	for scanner.Scan() {
+		fmt.Printf("line %d: %s\n", line, scanner.Text())
+		line++
+	}
+	return scanner.Err()
+}
+
+// teeWhileReading observes a stream as it is consumed: io.TeeReader copies
+// every byte read from the source into a writer — here a sha256 hash — so one
+// pass over the data yields both the payload and its checksum.
+func teeWhileReading() error {
+	fmt.Println("\n--- io.TeeReader (observe a stream while consuming it) ---")
+	hasher := sha256.New()
+	tee := io.TeeReader(strings.NewReader("hash me as I stream"), hasher)
+	payload, err := io.ReadAll(tee)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("consumed: %q\n", payload)
+	fmt.Printf("sha256:   %x\n", hasher.Sum(nil))
+	return nil
+}
+
+// writeOnceToMany fans a single write out to several sinks with io.MultiWriter —
+// the writer-side dual of TeeReader.
+func writeOnceToMany() error {
+	fmt.Println("\n--- io.MultiWriter (one write, several sinks) ---")
+	var first, second bytes.Buffer
+	hasher := sha256.New()
+	sink := io.MultiWriter(&first, &second, hasher)
+	if _, err := fmt.Fprint(sink, "fan out this write"); err != nil {
+		return err
+	}
+	fmt.Printf("buffer 1: %q\n", first.String())
+	fmt.Printf("buffer 2: %q\n", second.String())
+	fmt.Printf("sha256:   %x\n", hasher.Sum(nil))
+	return nil
+}
+
+// pipeAcrossGoroutines connects writer-shaped code (json.Encoder wants an
+// io.Writer) to reader-shaped code (io.ReadAll wants an io.Reader) without an
+// intermediate buffer. io.Pipe blocks each Write until the other side Reads,
+// so producer and consumer MUST run in different goroutines.
+func pipeAcrossGoroutines() error {
+	fmt.Println("\n--- io.Pipe (connect writer-shaped code to reader-shaped code) ---")
+	type event struct {
+		Name string `json:"name"`
+		Seq  int    `json:"seq"`
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		// CloseWithError(nil) closes normally; a non-nil error surfaces as the
+		// reading side's Read error instead of being silently dropped.
+		pw.CloseWithError(json.NewEncoder(pw).Encode(event{Name: "ping", Seq: 1}))
+	}()
+
+	payload, err := io.ReadAll(pr)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("received: %s", payload)
+	return nil
+}

--- a/go.work
+++ b/go.work
@@ -20,6 +20,7 @@ use (
 	./examples/http-client
 	./examples/http-server
 	./examples/inject
+	./examples/io-readers-writers
 	./examples/iterator
 	./examples/lambda
 	./examples/metric


### PR DESCRIPTION
## Summary
- New standalone-module example for the `io.Reader`/`io.Writer` contract and the stdlib stream combinators — the biggest gap in the Standard Library section (first of the Phase 1 additions)
- Six small, deterministic demos: manual `Read` loop (process bytes before checking the error), `io.Copy` + `io.LimitReader`, `bufio.Scanner`, `io.TeeReader` (one-pass payload+sha256), `io.MultiWriter` fan-out, and `io.Pipe` bridging `json.Encoder` to `io.ReadAll` across goroutines with `CloseWithError`
- No dependencies; full README per CONTRIBUTING template; registered in `go.work` and the root README index (Standard Library section)

## Test plan
- [x] `make run EXAMPLE=io-readers-writers` — output matches the README's Expected Output exactly (deterministic)
- [x] `make check EXAMPLE=io-readers-writers` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)