### PR TITLE
Add graceful-shutdown-signals example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [concurrency/fan-out-timeout](examples/concurrency/fan-out-timeout/) | Per-worker deadline with `time.After` |
 | [errgroup](examples/errgroup/) | `errgroup.WithContext` vs manual WaitGroup; `SetLimit` for bounded concurrency |
 | [pool](examples/pool/) | Generic worker pool with per-task error tracking |
+| [graceful-shutdown-signals](examples/graceful-shutdown-signals/) | `signal.NotifyContext`: SIGINT/SIGTERM as context cancellation, drain with a deadline |
 | [share-memory-by-communicating](examples/share-memory-by-communicating/) | URL poller via channels — from the Go blog |
 | [sync-primitives](examples/sync-primitives/) | `sync.Once`, `sync.Map`, and `atomic` operations |
 

--- a/examples/graceful-shutdown-signals/Makefile
+++ b/examples/graceful-shutdown-signals/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/graceful-shutdown-signals/README.md
+++ b/examples/graceful-shutdown-signals/README.md
@@ -1,0 +1,91 @@
+# Graceful Shutdown with OS Signals
+
+**Category:** concurrency
+**Difficulty:** Intermediate
+
+## Objective
+
+Show the standard shape of signal-driven graceful shutdown: `signal.NotifyContext` converts SIGINT/SIGTERM into context cancellation, workers treat cancellation as "finish what you're doing, then stop," and `main` enforces a shutdown deadline so one stuck worker can't hang the process forever. This is the pattern behind every well-behaved service under Kubernetes, systemd, or a terminal Ctrl+C.
+
+## Concepts Covered
+
+- `signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)` — signals as context cancellation, composable with everything else that takes a `context.Context`
+- Why `defer stop()` matters: it restores default signal handling, so a *second* Ctrl+C force-kills a shutdown that is itself stuck
+- `sync.WaitGroup.Go` (Go 1.25) — the one-call replacement for the `Add(1)` / `go` / `defer Done()` pattern
+- Draining: cancellation means "stop taking new work," not "drop the job in flight"
+- Bounding the wait: racing `wg.Wait()` (via a completion channel) against `time.After` because `WaitGroup` has no timeout of its own
+
+## Prerequisites
+
+- Go 1.25+ (uses `sync.WaitGroup.Go`)
+- No external services or environment variables required
+- The self-signaling demo (`SIGINT` to own pid) works on Linux/macOS; on Windows, run it and stop it with a real Ctrl+C instead
+
+## Project Structure
+
+```
+graceful-shutdown-signals/
+├── go.mod
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+The program stops on its own: after 300ms it sends SIGINT to itself, standing in for the operator's Ctrl+C. Press Ctrl+C earlier to trigger the same path manually.
+
+## Expected Output
+
+Worker lines can interleave in any order (they're independent goroutines); the `main:` lines always appear in this sequence:
+
+```
+main: 3 workers running; press Ctrl+C to stop
+worker 2: processing jobs
+worker 3: processing jobs
+worker 1: processing jobs
+main: simulating Ctrl+C (sending SIGINT to self)
+main: shutdown signal received; waiting up to 2s for workers
+worker 3: shutdown requested, draining current job
+worker 2: shutdown requested, draining current job
+worker 1: shutdown requested, draining current job
+worker 1: stopped
+worker 3: stopped
+worker 2: stopped
+main: all workers stopped cleanly
+```
+
+## Code Walkthrough
+
+- `signal.NotifyContext` returns a context that's canceled on the first SIGINT or SIGTERM. Because shutdown arrives as *context cancellation*, everything downstream that already accepts a context — workers here, but equally HTTP servers, database calls, message consumers — participates in shutdown with no extra plumbing.
+- The deferred `stop()` is not just cleanup: while the returned context is armed, the signals are *captured* and no longer kill the process. `stop()` re-enables default handling, so if graceful shutdown itself wedges, the operator's second Ctrl+C still works. Forgetting this is how services end up needing `kill -9`.
+- Each worker `select`s between `ctx.Done()` and its work source (a ticker standing in for a job queue). On cancellation it finishes the in-flight job (simulated by the 50ms sleep) before returning — cancellation is a request to wind down, not to abort mid-write.
+- `wg.Go(func() { worker(ctx, id) })` (Go 1.25) replaces the classic three-line `Add`/`go`/`defer Done()` dance and makes the off-by-one `Add` mistakes impossible.
+- `wg.Wait()` blocks forever if a worker never returns, so `run` waits for it in a goroutine that closes `workersDone`, then races that channel against `time.After(shutdownTimeout)`. On timeout the process exits nonzero — deliberately, since a supervisor (Kubernetes, systemd) will escalate to SIGKILL anyway, and exiting with an error is more honest than hanging.
+- `signalSelf` exists only so the demo terminates deterministically: it delivers a real SIGINT through `os.FindProcess(os.Getpid()).Signal`, exercising the actual signal path rather than faking cancellation.
+
+## Common Pitfalls
+
+- **Calling `stop()` (or `signal.Reset`) too early.** If you release the signal registration before shutdown finishes, an impatient second Ctrl+C kills the process mid-drain. Deferring `stop()` in `main`/`run` gets the order right: capture → drain → restore.
+- **Treating cancellation as "abort now."** Dropping an in-flight job on `ctx.Done()` can lose data (half-written files, unacked messages). Check for cancellation *between* units of work, not in the middle of one — or pass the context into the work itself if it's long-running.
+- **Waiting on `wg.Wait()` with no deadline.** One worker blocked on an unresponsive dependency turns "graceful shutdown" into "hangs until SIGKILL." Always bound the wait and exit nonzero on timeout.
+- **Ignoring SIGTERM.** Terminals send SIGINT, but orchestrators (Kubernetes, Docker, systemd) send SIGTERM first and SIGKILL after a grace period. Registering only `os.Interrupt` means your service never sees Kubernetes asking nicely.
+- **Doing real work in the signal-handling goroutine.** With `NotifyContext` there's no handler goroutine to misuse — another reason to prefer it over a raw `signal.Notify` channel unless you need per-signal behavior (e.g. SIGHUP for config reload).
+
+## References
+
+- [os/signal package docs — NotifyContext](https://pkg.go.dev/os/signal#NotifyContext)
+- [sync package docs — WaitGroup.Go](https://pkg.go.dev/sync#WaitGroup.Go)
+- [Go Blog — Context and structs](https://go.dev/blog/context-and-structs)
+
+## Next Steps
+
+- [http-server](../http-server/) — the same idea applied to `http.Server.Shutdown` with in-flight requests
+- [context](../context/) — the cancellation machinery this pattern is built on
+- [concurrency/worker-pool](../concurrency/worker-pool/) — the worker/job-channel structure these workers sketch

--- a/examples/graceful-shutdown-signals/go.mod
+++ b/examples/graceful-shutdown-signals/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/graceful-shutdown-signals
+
+go 1.25.0

--- a/examples/graceful-shutdown-signals/main.go
+++ b/examples/graceful-shutdown-signals/main.go
@@ -1,0 +1,106 @@
+// Demonstrates graceful shutdown driven by OS signals: signal.NotifyContext
+// turns SIGINT/SIGTERM into context cancellation, workers drain in-flight work,
+// and main enforces a deadline so a stuck worker can't hang the exit forever.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	numWorkers      = 3
+	demoSignalAfter = 300 * time.Millisecond
+	shutdownTimeout = 2 * time.Second
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// ctx is canceled on the first SIGINT/SIGTERM. stop() then restores the
+	// default signal handling, so a second Ctrl+C kills the process
+	// immediately instead of being swallowed by a shutdown that might itself
+	// be stuck — always defer it.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	var wg sync.WaitGroup
+	for id := 1; id <= numWorkers; id++ {
+		// WaitGroup.Go (Go 1.25) wraps the Add(1)/go/defer Done() dance.
+		wg.Go(func() {
+			worker(ctx, id)
+		})
+	}
+	fmt.Printf("main: %d workers running; press Ctrl+C to stop\n", numWorkers)
+
+	// So the demo terminates on its own, simulate the operator's Ctrl+C by
+	// sending SIGINT to our own process after a short delay. A real service
+	// would simply block on <-ctx.Done() until Kubernetes, systemd, or a
+	// human delivers the signal.
+	go func() {
+		time.Sleep(demoSignalAfter)
+		fmt.Println("main: simulating Ctrl+C (sending SIGINT to self)")
+		if err := signalSelf(); err != nil {
+			fmt.Fprintln(os.Stderr, "demo: could not send SIGINT:", err)
+		}
+	}()
+
+	<-ctx.Done()
+	fmt.Printf("main: shutdown signal received; waiting up to %s for workers\n", shutdownTimeout)
+
+	// wg.Wait has no timeout, so wait for it in a goroutine and race the
+	// completion channel against a deadline.
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(workersDone)
+	}()
+
+	select {
+	case <-workersDone:
+		fmt.Println("main: all workers stopped cleanly")
+		return nil
+	case <-time.After(shutdownTimeout):
+		return fmt.Errorf("shutdown timed out after %s: exiting with workers still running", shutdownTimeout)
+	}
+}
+
+// worker processes jobs until its context is canceled, then finishes the job
+// in flight before returning — cancellation is a request to stop taking new
+// work, not permission to drop what's already started.
+func worker(ctx context.Context, id int) {
+	fmt.Printf("worker %d: processing jobs\n", id)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Printf("worker %d: shutdown requested, draining current job\n", id)
+			time.Sleep(50 * time.Millisecond) // simulate finishing in-flight work
+			fmt.Printf("worker %d: stopped\n", id)
+			return
+		case <-ticker.C:
+			// simulate picking up and completing a job
+		}
+	}
+}
+
+// signalSelf delivers SIGINT to this process — the programmatic equivalent of
+// the operator pressing Ctrl+C in the terminal.
+func signalSelf() error {
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return err
+	}
+	return proc.Signal(os.Interrupt)
+}

--- a/go.work
+++ b/go.work
@@ -17,6 +17,7 @@ use (
 	./examples/functional-options
 	./examples/generics
 	./examples/gin
+	./examples/graceful-shutdown-signals
 	./examples/http-client
 	./examples/http-server
 	./examples/inject


### PR DESCRIPTION
## Summary
- New standalone-module example for signal-driven graceful shutdown (`signal.NotifyContext`), second of the Phase 1 additions
- SIGINT/SIGTERM arrive as context cancellation; workers drain in-flight work instead of aborting; `main` races `wg.Wait` against a 2s deadline so a stuck worker can't hang the exit
- Showcases `sync.WaitGroup.Go` (Go 1.25) and documents why `defer stop()` matters (second Ctrl+C force-kills a wedged shutdown)
- Deterministic: the demo self-delivers a real SIGINT after 300ms, exercising the actual signal path while letting `go run .` terminate on its own
- No dependencies; full README; registered in `go.work` and the root README index (Concurrency section)

## Test plan
- [x] `make run EXAMPLE=graceful-shutdown-signals` — starts, self-signals, drains all 3 workers, exits 0
- [x] `make check EXAMPLE=graceful-shutdown-signals` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)