### PR TITLE
Add mocking example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 |-----------|-------------|
 | [testing-patterns](examples/testing-patterns/) | Table-driven tests, `t.Parallel`, subtests, fuzz testing, `TestMain` |
 | [httptest](examples/httptest/) | Handler tests with `httptest.NewRecorder`, client tests with `httptest.NewServer` |
+| [mocking](examples/mocking/) | Hand-rolled test doubles via interfaces: stub, mock, fake, func adapter |
 
 ### Patterns & Design
 

--- a/examples/mocking/Makefile
+++ b/examples/mocking/Makefile
@@ -1,0 +1,24 @@
+## run: the demonstration lives in the tests; see `make test`
+.PHONY: run
+run:
+	go run .
+
+## test: run the mocking demonstration (the actual example)
+.PHONY: test
+test:
+	go test -race -count=1 -v ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/mocking/README.md
+++ b/examples/mocking/README.md
@@ -1,0 +1,86 @@
+# Mocking with Interfaces
+
+**Category:** testing
+**Difficulty:** Intermediate
+
+## Objective
+
+Show how far plain Go interfaces go for test doubles — no framework required. A small service with two dependency seams (`UserStore`, `Mailer`) is tested with the three classic double flavors: a **stub** (canned answers), a **mock** (records calls for interaction assertions), and a **fake** (a real implementation with a shortcut), plus the function-adapter trick for one-off inline doubles.
+
+## Concepts Covered
+
+- Consumer-defined interfaces: the service declares the `UserStore`/`Mailer` it *needs*, so implementations (real or test) satisfy it implicitly — the seam that makes substitution free
+- Stub vs mock vs fake, and which each is for: output you need vs interaction you assert vs stateful behavior many tests share
+- The `http.HandlerFunc` adapter trick (`MailerFunc`) — a closure as a complete test double
+- Asserting the *negative* interaction: on lookup failure, the mailer must not have been called
+- Error wrapping (`%w`) verified with `errors.Is` through the service boundary
+- Constructor injection (`NewWelcomeService(store, mailer)`) as the wiring that makes all of this possible
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+mocking/
+├── go.mod
+├── main.go          # WelcomeService and its two dependency seams
+├── main_test.go     # stub, mock, fake, func-adapter — the actual demonstration
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+The demonstration lives in the tests (`main.go`'s `main` only points you there):
+
+```bash
+make test
+# or
+go test -race -count=1 -v ./...
+```
+
+## Expected Output
+
+Abridged — tests run in parallel, so ordering interleaves:
+
+```
+--- PASS: TestWelcomeSendsEmail (0.00s)
+--- PASS: TestWelcomeStoreFailureSkipsEmail (0.00s)
+--- PASS: TestWelcomeWrapsMailerError (0.00s)
+--- PASS: TestWelcomeWithFuncDouble (0.00s)
+--- PASS: TestWelcomeWithFake (0.00s)
+PASS
+```
+
+## Code Walkthrough
+
+- `WelcomeService.Welcome` is deliberately ordinary application code: look up, compose, send, wrap errors. What makes it testable is entirely in the signatures — it depends on two small interfaces it defines itself, injected through the constructor. This is the Go norm: **interfaces live with the consumer**, so the service compiles against exactly the behavior it uses and nothing more.
+- `stubUserStore` (a *stub*) returns whatever `user`/`err` the test configured. Value receiver, no state, three lines — this is the workhorse double for "arrange" data.
+- `mockMailer` (a *mock*) appends every `Send` to a slice so tests can assert interactions: `TestWelcomeSendsEmail` checks recipient and subject; `TestWelcomeStoreFailureSkipsEmail` checks the more interesting property that **no** email goes out when the lookup fails. Its `err` field also makes it a failure injector (`TestWelcomeWrapsMailerError`).
+- `fakeUserStore` (a *fake*) actually works — a map with the same semantics a database adapter would have, including `ErrUserNotFound`. Fakes cost more to write but pay off when many tests need consistent stateful behavior instead of per-test canned answers.
+- `MailerFunc` adapts a function to the `Mailer` interface exactly like `http.HandlerFunc` adapts to `http.Handler`. For a single-method interface, that means an inline closure is a full double (`TestWelcomeWithFuncDouble`) — often the lightest option of all.
+- Error paths are asserted with `errors.Is` against the sentinel/wrapped error, not string matching — the same wrapping discipline shown in the [errors](../errors/) example.
+
+## Common Pitfalls
+
+- **Defining interfaces next to the implementation and mocking those.** If the interface belongs to the producer, it accretes methods the consumer never uses, and every double must implement all of them. Keep interfaces small and consumer-side; a one- or two-method interface makes hand-rolled doubles trivial.
+- **Over-asserting on interactions.** Checking that the mailer was called once with the right recipient is the contract; asserting the exact body string in *every* test couples all of them to copy changes. Assert interactions where the interaction *is* the behavior, values where the value is.
+- **Mocking what you don't own.** Wrapping `*sql.DB` or an AWS SDK client in your own small interface (`UserStore`) and mocking *that* is robust; trying to fake the SDK's entire surface is not. Adapt third-party types behind your own seam first.
+- **Reaching for a framework by default.** `gomock`/`mockery` (generated mocks) and `testify/mock` earn their keep with large interfaces, many call expectations, or codebase-wide consistency — but they add generation steps and a DSL. For seams like this one, the hand-rolled version is shorter than the framework's setup code.
+- **Races in doubles.** If the code under test calls a double from multiple goroutines, the double needs the same synchronization a real implementation would (`mockMailer` guards its slice with a mutex) — otherwise `-race` flags your test double instead of your code.
+
+## References
+
+- [Go Code Review Comments — Interfaces](https://go.dev/wiki/CodeReviewComments#interfaces)
+- [Google Go Style Decisions — Interfaces](https://google.github.io/styleguide/go/decisions#interfaces)
+- [Martin Fowler — Mocks Aren't Stubs](https://martinfowler.com/articles/mocksArentStubs.html)
+- [gomock](https://github.com/uber-go/mock) / [mockery](https://github.com/vektra/mockery) — generation-based alternatives for large interfaces
+
+## Next Steps
+
+- [inject](../inject/) — the constructor-injection pattern these seams rely on
+- [httptest](../httptest/) — the specialized doubles the stdlib ships for HTTP
+- [errors](../errors/) — the wrapping/`errors.Is` discipline the assertions here use

--- a/examples/mocking/go.mod
+++ b/examples/mocking/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/mocking
+
+go 1.25.0

--- a/examples/mocking/main.go
+++ b/examples/mocking/main.go
@@ -1,0 +1,72 @@
+// Demonstrates hand-rolled test doubles (stubs, mocks, fakes) built on plain
+// Go interfaces — the reason to accept interfaces at dependency seams is that
+// tests can then substitute behavior with a few lines of code and no framework.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// User is the domain entity the service works with.
+type User struct {
+	ID    string
+	Name  string
+	Email string
+}
+
+// ErrUserNotFound is returned by UserStore implementations when the id is unknown.
+var ErrUserNotFound = errors.New("user not found")
+
+// UserStore is the persistence seam. The service defines the interface it
+// *consumes* (Go style: interfaces belong to the consumer, not the implementer),
+// so any storage — Postgres, DynamoDB, or a test double — can satisfy it.
+type UserStore interface {
+	GetUser(ctx context.Context, id string) (User, error)
+}
+
+// Mailer is the outbound-delivery seam.
+type Mailer interface {
+	Send(ctx context.Context, to, subject, body string) error
+}
+
+// MailerFunc adapts a plain function to the Mailer interface — the http.HandlerFunc
+// trick. Tests can define one-off mailers inline without declaring a type.
+type MailerFunc func(ctx context.Context, to, subject, body string) error
+
+// Send calls f.
+func (f MailerFunc) Send(ctx context.Context, to, subject, body string) error {
+	return f(ctx, to, subject, body)
+}
+
+// WelcomeService is the unit under test: look a user up, send them a welcome
+// email, and translate failures from either dependency into wrapped errors.
+type WelcomeService struct {
+	store  UserStore
+	mailer Mailer
+}
+
+// NewWelcomeService wires the service's dependencies.
+func NewWelcomeService(store UserStore, mailer Mailer) *WelcomeService {
+	return &WelcomeService{store: store, mailer: mailer}
+}
+
+// Welcome sends the welcome email for the given user id.
+func (s *WelcomeService) Welcome(ctx context.Context, userID string) error {
+	user, err := s.store.GetUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("looking up user %s: %w", userID, err)
+	}
+
+	subject := "Welcome!"
+	body := fmt.Sprintf("Hi %s, thanks for signing up.", user.Name)
+	if err := s.mailer.Send(ctx, user.Email, subject, body); err != nil {
+		return fmt.Errorf("sending welcome email to %s: %w", user.Email, err)
+	}
+	return nil
+}
+
+func main() {
+	fmt.Println("this example's demonstration lives in its tests — run `make test` (or `go test -v ./...`)")
+}

--- a/examples/mocking/main_test.go
+++ b/examples/mocking/main_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// --- test doubles -----------------------------------------------------------
+
+// stubUserStore is a STUB: it returns canned answers and records nothing.
+// Stubs are for dependencies whose output the test needs but whose usage it
+// doesn't verify.
+type stubUserStore struct {
+	user User
+	err  error
+}
+
+func (s stubUserStore) GetUser(context.Context, string) (User, error) {
+	return s.user, s.err
+}
+
+// mockMailer is a MOCK: it records how it was called so the test can assert
+// on the interaction (who was emailed, how many times), and can be programmed
+// to fail.
+type mockMailer struct {
+	mu    sync.Mutex
+	calls []sendCall
+	err   error
+}
+
+type sendCall struct {
+	To, Subject, Body string
+}
+
+func (m *mockMailer) Send(_ context.Context, to, subject, body string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, sendCall{To: to, Subject: subject, Body: body})
+	return m.err
+}
+
+// fakeUserStore is a FAKE: a real, working implementation with a shortcut
+// (a map instead of a database). Fakes shine when many tests need consistent,
+// stateful behavior rather than one canned answer.
+type fakeUserStore struct {
+	mu    sync.Mutex
+	users map[string]User
+}
+
+func newFakeUserStore(users ...User) *fakeUserStore {
+	f := &fakeUserStore{users: make(map[string]User)}
+	for _, u := range users {
+		f.users[u.ID] = u
+	}
+	return f
+}
+
+func (f *fakeUserStore) GetUser(_ context.Context, id string) (User, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	user, ok := f.users[id]
+	if !ok {
+		return User{}, ErrUserNotFound
+	}
+	return user, nil
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestWelcomeSendsEmail(t *testing.T) {
+	t.Parallel()
+	store := stubUserStore{user: User{ID: "42", Name: "Ada", Email: "ada@example.com"}}
+	mailer := &mockMailer{}
+	svc := NewWelcomeService(store, mailer)
+
+	if err := svc.Welcome(t.Context(), "42"); err != nil {
+		t.Fatalf("Welcome: %v", err)
+	}
+
+	if len(mailer.calls) != 1 {
+		t.Fatalf("mailer called %d times, want 1", len(mailer.calls))
+	}
+	call := mailer.calls[0]
+	if call.To != "ada@example.com" {
+		t.Errorf("sent to %q, want %q", call.To, "ada@example.com")
+	}
+	if call.Subject != "Welcome!" {
+		t.Errorf("subject %q, want %q", call.Subject, "Welcome!")
+	}
+}
+
+func TestWelcomeStoreFailureSkipsEmail(t *testing.T) {
+	t.Parallel()
+	store := stubUserStore{err: ErrUserNotFound}
+	mailer := &mockMailer{}
+	svc := NewWelcomeService(store, mailer)
+
+	err := svc.Welcome(t.Context(), "missing")
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("Welcome error = %v, want wrapped ErrUserNotFound", err)
+	}
+	if len(mailer.calls) != 0 {
+		t.Errorf("mailer called %d times, want 0 — no email on lookup failure", len(mailer.calls))
+	}
+}
+
+func TestWelcomeWrapsMailerError(t *testing.T) {
+	t.Parallel()
+	errSMTP := errors.New("smtp: connection refused")
+	store := stubUserStore{user: User{ID: "42", Name: "Ada", Email: "ada@example.com"}}
+	mailer := &mockMailer{err: errSMTP}
+	svc := NewWelcomeService(store, mailer)
+
+	err := svc.Welcome(t.Context(), "42")
+	if !errors.Is(err, errSMTP) {
+		t.Fatalf("Welcome error = %v, want wrapped %v", err, errSMTP)
+	}
+}
+
+// TestWelcomeWithFuncDouble shows the function-adapter trick: for a one-off
+// behavior, a MailerFunc closure is a complete test double — no type needed.
+func TestWelcomeWithFuncDouble(t *testing.T) {
+	t.Parallel()
+	store := stubUserStore{user: User{ID: "7", Name: "Lin", Email: "lin@example.com"}}
+
+	var gotBody string
+	mailer := MailerFunc(func(_ context.Context, _, _, body string) error {
+		gotBody = body
+		return nil
+	})
+
+	if err := NewWelcomeService(store, mailer).Welcome(t.Context(), "7"); err != nil {
+		t.Fatalf("Welcome: %v", err)
+	}
+	if want := "Hi Lin, thanks for signing up."; gotBody != want {
+		t.Errorf("body = %q, want %q", gotBody, want)
+	}
+}
+
+// TestWelcomeWithFake exercises the service against the stateful fake:
+// present and missing users behave like a real store would.
+func TestWelcomeWithFake(t *testing.T) {
+	t.Parallel()
+	store := newFakeUserStore(User{ID: "1", Name: "Grace", Email: "grace@example.com"})
+	mailer := &mockMailer{}
+	svc := NewWelcomeService(store, mailer)
+
+	if err := svc.Welcome(t.Context(), "1"); err != nil {
+		t.Fatalf("Welcome existing user: %v", err)
+	}
+	if err := svc.Welcome(t.Context(), "2"); !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("Welcome missing user error = %v, want ErrUserNotFound", err)
+	}
+	if len(mailer.calls) != 1 {
+		t.Errorf("mailer called %d times, want exactly 1", len(mailer.calls))
+	}
+}

--- a/go.work
+++ b/go.work
@@ -26,6 +26,7 @@ use (
 	./examples/iterator
 	./examples/lambda
 	./examples/metric
+	./examples/mocking
 	./examples/mysql
 	./examples/oop
 	./examples/oop/composition


### PR DESCRIPTION
## Summary
- New standalone-module example for hand-rolled test doubles built on consumer-defined interfaces — stdlib-first, no framework — fourth of the Phase 1 additions
- A small `WelcomeService` with two dependency seams (`UserStore`, `Mailer`) is tested with the three classic double flavors: **stub** (canned answers), **recording mock** (interaction assertions, including the negative case: no email may be sent when the lookup fails), and **stateful fake** (map-backed store with real semantics), plus the `http.HandlerFunc`-style function adapter (`MailerFunc`) for inline one-off doubles
- Error paths asserted with `errors.Is` through `%w`-wrapped errors; doubles are race-safe under `-race`
- README covers when generation-based frameworks (gomock/mockery, testify) earn their keep instead

## Test plan
- [x] `make test EXAMPLE=mocking` — 5 tests pass with `-race`, fully parallel
- [x] `make check EXAMPLE=mocking` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)