### PR TITLE
Add concurrency/pipeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [concurrency/worker-pool](examples/concurrency/worker-pool/) | Fixed pool consuming a shared job channel |
 | [concurrency/scatter-gather](examples/concurrency/scatter-gather/) | One goroutine per task, collect all results |
 | [concurrency/fan-out-timeout](examples/concurrency/fan-out-timeout/) | Per-worker deadline with `time.After` |
+| [concurrency/pipeline](examples/concurrency/pipeline/) | Staged channels, fan-in `merge`, cancellation without goroutine leaks |
 | [errgroup](examples/errgroup/) | `errgroup.WithContext` vs manual WaitGroup; `SetLimit` for bounded concurrency |
 | [pool](examples/pool/) | Generic worker pool with per-task error tracking |
 | [graceful-shutdown-signals](examples/graceful-shutdown-signals/) | `signal.NotifyContext`: SIGINT/SIGTERM as context cancellation, drain with a deadline |

--- a/examples/concurrency/pipeline/Makefile
+++ b/examples/concurrency/pipeline/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/concurrency/pipeline/README.md
+++ b/examples/concurrency/pipeline/README.md
@@ -1,0 +1,81 @@
+# Pipeline
+
+**Category:** concurrency
+**Difficulty:** Intermediate
+
+## Objective
+
+Show the pipeline pattern from the Go blog: independent stages connected by channels, where an upstream `close` propagates termination downstream through `range`, `merge` fans several streams into one, and context cancellation lets a consumer walk away early without leaking producer goroutines. Every stage goroutine is registered in a `sync.WaitGroup`, so the example *proves* the no-leak property instead of asserting it in a comment.
+
+## Concepts Covered
+
+- Stage shape: own your output channel, `defer close(out)`, `range` your input — close propagation is what terminates the whole chain
+- `select { case out <- v: case <-ctx.Done(): }` on **every send** — the modern form of the Go blog's `done` channel, and the single detail that makes early cancellation leak-free
+- Fan-in (`merge`): one forwarder per input plus a closer goroutine that waits for all forwarders — and why fan-in gives up ordering
+- Work sharing: two `square` stages ranging over the *same* input channel split the values between them
+- `sync.WaitGroup.Go` (Go 1.25) tracking every stage goroutine so `wg.Wait()` verifies clean shutdown
+
+## Prerequisites
+
+- Go 1.25+ (uses `sync.WaitGroup.Go`)
+- No external services or environment variables required
+
+## Project Structure
+
+```
+pipeline/
+├── go.mod
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+--- linear pipeline: gen -> square ---
+1 4 9 16 25
+
+--- fan-in: two square stages share the work, merged ---
+1 4 9 16 25 36 49 64 81 100 (sorted; arrival order varies)
+
+--- early cancellation: take 3 of 1000, then cancel ---
+took: 1 4 9
+all stage goroutines exited — no leaks
+```
+
+## Code Walkthrough
+
+- `gen` and `square` have the canonical stage shape: they *own* the channel they return, close it on the way out (`defer close(out)`), and guard every send with a `select` on `ctx.Done()`. Ownership is the discipline that makes `close` safe — only the sender closes, exactly once.
+- In `linearPipeline`, nothing but `range` is needed on the consuming side: when `gen` runs out of numbers it closes its channel, `square`'s `range` ends, `square` closes its channel, the consumer's `range` ends. Termination is data-driven; no coordination code.
+- `fanInPipeline` starts **two** `square` stages reading the same `gen` channel — each value is received by exactly one of them, so the work is split. `merge` then funnels both outputs into one channel: a forwarder goroutine per input, plus a closer that waits on the forwarders' own WaitGroup before `close(out)`. Without that closer the consumer's `range` would block forever; with it, but closing too early, values would be dropped. The output arrives in whatever order the two stages produce it — the example sorts before printing, a real consumer must either not care or reattach sequence numbers.
+- `earlyCancellation` is why the `ctx` plumbing exists. The consumer takes 3 values from a 1000-value pipeline and `break`s. At that moment `square` is blocked sending value #4 and `gen` is blocked sending a later number — with a bare `out <- v` they would block forever, invisible until the process's goroutine count climbs. `cancel()` makes every blocked send's `select` take the `ctx.Done()` arm, and `wg.Wait()` returning is the proof that all four goroutines exited.
+- The WaitGroup threading (`wg.Go` inside each stage constructor) isn't part of the classic pattern — it's here to make goroutine lifetimes observable. In production the same role is played by `errgroup.Group` (see [errgroup](../../errgroup/)), which adds error propagation.
+
+## Common Pitfalls
+
+- **A send without a `select` on cancellation.** `out <- n` in a stage is correct *only* if the consumer is guaranteed to drain the channel. Any consumer that can stop early (errors, limits, timeouts) turns that send into a permanent goroutine leak.
+- **Closing a channel you don't own, or from the receiving side.** Close is a sender-side, owner-only operation; double-close or send-on-closed panics come from breaking this rule. Each stage closing only its own output is what keeps the property local and auditable.
+- **Forgetting `merge`'s closer goroutine.** If nobody closes the merged channel, the consumer's `range` never terminates — the pipeline "works" but the program hangs at the end.
+- **Assuming fan-in preserves order.** It doesn't, by design. If order matters, don't fan out (keep one stage), or tag values with an index and reorder at the sink.
+- **Unbounded buffering as a substitute for cancellation.** Buffered channels can mask the leak (sends succeed into the buffer), but the goroutines and memory still linger; buffers size throughput, they don't manage lifetimes.
+
+## References
+
+- [Go Blog — Go Concurrency Patterns: Pipelines and cancellation](https://go.dev/blog/pipelines)
+- [Go Blog — Share Memory By Communicating](https://go.dev/blog/codelab-share)
+- [sync package docs — WaitGroup.Go](https://pkg.go.dev/sync#WaitGroup.Go)
+
+## Next Steps
+
+- [errgroup](../../errgroup/) — the production version of the WaitGroup threading here, with error propagation
+- [concurrency/worker-pool](../worker-pool/) — a fixed pool consuming one job channel, the sibling pattern
+- [concurrency/fan-out-timeout](../fan-out-timeout/) — per-worker deadlines instead of whole-pipeline cancellation

--- a/examples/concurrency/pipeline/go.mod
+++ b/examples/concurrency/pipeline/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/concurrency/pipeline
+
+go 1.25.0

--- a/examples/concurrency/pipeline/main.go
+++ b/examples/concurrency/pipeline/main.go
@@ -1,0 +1,154 @@
+// Demonstrates the pipeline concurrency pattern from the Go blog: stages
+// connected by channels, upstream close propagating downstream via range,
+// fan-in with a WaitGroup, and context cancellation so a consumer that stops
+// early doesn't leak producer goroutines. Every stage goroutine is tracked in
+// a WaitGroup so the no-leak claim is verified, not assumed.
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// gen emits the given numbers on its output channel, then closes it. The
+// close is what lets downstream stages use plain `range`. The select on
+// ctx.Done() is what lets an abandoned stage exit instead of blocking on a
+// send forever — the Go blog's `done` channel, in its modern context form.
+func gen(ctx context.Context, wg *sync.WaitGroup, nums ...int) <-chan int {
+	out := make(chan int)
+	wg.Go(func() {
+		defer close(out)
+		for _, n := range nums {
+			select {
+			case out <- n:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+	return out
+}
+
+// square reads from in until it's closed (or the context is canceled) and
+// emits each value squared. Same shape as gen: close on the way out,
+// select on every send.
+func square(ctx context.Context, wg *sync.WaitGroup, in <-chan int) <-chan int {
+	out := make(chan int)
+	wg.Go(func() {
+		defer close(out)
+		for n := range in {
+			select {
+			case out <- n * n:
+			case <-ctx.Done():
+				return
+			}
+		}
+	})
+	return out
+}
+
+// merge fans multiple input channels into one: a forwarding goroutine per
+// input, and one more that closes the output when all forwarders finish —
+// without that closer, downstream range loops would never terminate.
+func merge(ctx context.Context, wg *sync.WaitGroup, ins ...<-chan int) <-chan int {
+	out := make(chan int)
+
+	var forwarders sync.WaitGroup
+	for _, in := range ins {
+		forwarders.Add(1)
+		wg.Go(func() {
+			defer forwarders.Done()
+			for n := range in {
+				select {
+				case out <- n:
+				case <-ctx.Done():
+					return
+				}
+			}
+		})
+	}
+
+	wg.Go(func() {
+		forwarders.Wait()
+		close(out)
+	})
+	return out
+}
+
+func main() {
+	linearPipeline()
+	fanInPipeline()
+	earlyCancellation()
+}
+
+// linearPipeline chains two stages; the consumer is just a range loop, and
+// termination flows from gen's close through square's close.
+func linearPipeline() {
+	fmt.Println("--- linear pipeline: gen -> square ---")
+	ctx := context.Background()
+	var wg sync.WaitGroup
+
+	var results []string
+	for v := range square(ctx, &wg, gen(ctx, &wg, 1, 2, 3, 4, 5)) {
+		results = append(results, fmt.Sprint(v))
+	}
+	wg.Wait()
+	fmt.Println(strings.Join(results, " "))
+}
+
+// fanInPipeline runs two square stages reading the same gen channel — the
+// work is split between them — and merges their outputs. Fan-in trades away
+// ordering for parallelism, so the results are sorted before printing.
+func fanInPipeline() {
+	fmt.Println("\n--- fan-in: two square stages share the work, merged ---")
+	ctx := context.Background()
+	var wg sync.WaitGroup
+
+	nums := gen(ctx, &wg, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+	merged := merge(ctx, &wg, square(ctx, &wg, nums), square(ctx, &wg, nums))
+
+	var results []int
+	for v := range merged {
+		results = append(results, v)
+	}
+	wg.Wait()
+
+	slices.Sort(results)
+	out := make([]string, len(results))
+	for i, v := range results {
+		out[i] = fmt.Sprint(v)
+	}
+	fmt.Println(strings.Join(out, " ") + " (sorted; arrival order varies)")
+}
+
+// earlyCancellation is the case the ctx plumbing exists for: the consumer
+// takes 3 of 1000 values and walks away. cancel() unblocks the stages stuck
+// on sends, and wg.Wait() proves every goroutine exited — no leaks.
+func earlyCancellation() {
+	fmt.Println("\n--- early cancellation: take 3 of 1000, then cancel ---")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+
+	big := make([]int, 1000)
+	for i := range big {
+		big[i] = i + 1
+	}
+	squares := square(ctx, &wg, gen(ctx, &wg, big...))
+
+	var taken []string
+	for v := range squares {
+		taken = append(taken, fmt.Sprint(v))
+		if len(taken) == 3 {
+			break // consumer bails out mid-stream
+		}
+	}
+	cancel() // tell upstream stages to stop; without this, they'd block forever
+	wg.Wait()
+
+	fmt.Println("took: " + strings.Join(taken, " "))
+	fmt.Println("all stage goroutines exited — no leaks")
+}

--- a/go.work
+++ b/go.work
@@ -4,6 +4,7 @@ use (
 	./examples/benchmark
 	./examples/channels
 	./examples/concurrency/fan-out-timeout
+	./examples/concurrency/pipeline
 	./examples/concurrency/scatter-gather
 	./examples/concurrency/worker-pool
 	./examples/config


### PR DESCRIPTION
## Summary
- New standalone-module example for the Go blog pipeline pattern, first of the Phase 2 additions — completes the `concurrency/*` family alongside worker-pool, scatter-gather, and fan-out-timeout
- Three deterministic demos: a linear gen→square chain terminated purely by close propagation; fan-in where two `square` stages split one input channel and `merge` funnels them (sorted before printing — fan-in gives up ordering); and early cancellation where the consumer takes 3 of 1000 values, `cancel()` unblocks the stages, and `wg.Wait()` proves no goroutine leaked
- Every stage goroutine is tracked with `sync.WaitGroup.Go` (Go 1.25), making the no-leak property verifiable instead of asserted
- No dependencies; full README; registered in `go.work` and the root README index

## Test plan
- [x] `make run EXAMPLE=concurrency/pipeline` — output matches the README exactly
- [x] `make check EXAMPLE=concurrency/pipeline` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)