### PR TITLE
Add concurrency/rate-limiting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [concurrency/scatter-gather](examples/concurrency/scatter-gather/) | One goroutine per task, collect all results |
 | [concurrency/fan-out-timeout](examples/concurrency/fan-out-timeout/) | Per-worker deadline with `time.After` |
 | [concurrency/pipeline](examples/concurrency/pipeline/) | Staged channels, fan-in `merge`, cancellation without goroutine leaks |
+| [concurrency/rate-limiting](examples/concurrency/rate-limiting/) | `time.Ticker` vs `x/time/rate`: `Allow` to shed load, `Wait` to pace |
 | [errgroup](examples/errgroup/) | `errgroup.WithContext` vs manual WaitGroup; `SetLimit` for bounded concurrency |
 | [pool](examples/pool/) | Generic worker pool with per-task error tracking |
 | [graceful-shutdown-signals](examples/graceful-shutdown-signals/) | `signal.NotifyContext`: SIGINT/SIGTERM as context cancellation, drain with a deadline |

--- a/examples/concurrency/rate-limiting/Makefile
+++ b/examples/concurrency/rate-limiting/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/concurrency/rate-limiting/README.md
+++ b/examples/concurrency/rate-limiting/README.md
@@ -1,0 +1,92 @@
+# Rate Limiting
+
+**Category:** concurrency
+**Difficulty:** Intermediate
+
+## Objective
+
+Show the two standard ways to rate-limit in Go and when each fits: a `time.Ticker` as a rigid fixed-cadence limiter, and `golang.org/x/time/rate`'s token bucket — `Allow` for load-shedding decisions (answer 429 now) and `Wait` for pacing work under a quota (delay, don't drop). The demo verifies its own pacing guarantee instead of printing machine-dependent timings.
+
+## Concepts Covered
+
+- `time.Ticker` as a one-request-per-tick limiter, and why it's the weakest option (no bursts, fixed slot size)
+- The token-bucket model: refill rate (`rate.Limit`) vs bucket size (`burst`), and how burst absorbs spikes while the rate bounds the steady state
+- `Limiter.Allow` — non-blocking take-or-reject, the server-side load-shedding shape
+- `Limiter.Wait(ctx)` — blocking until a token is available, the client-side quota-respecting shape, with context cancellation cutting the wait short
+- Verifying timing behavior structurally (elapsed ≥ guaranteed minimum) rather than printing raw durations
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required — the single dependency (`golang.org/x/time`) is the canonical rate-limiting package and the thing being taught
+
+## Project Structure
+
+```
+rate-limiting/
+├── go.mod
+├── go.sum
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+--- time.Ticker: fixed cadence, one request per tick ---
+request 1 processed on its tick
+request 2 processed on its tick
+request 3 processed on its tick
+request 4 processed on its tick
+
+--- rate.Limiter Allow: refill 10/s, burst 3 — shed what overflows ---
+request 1: allowed (token consumed)
+request 2: allowed (token consumed)
+request 3: allowed (token consumed)
+request 4: rejected — bucket empty, a real server would answer 429
+request 5: rejected — bucket empty, a real server would answer 429
+
+--- rate.Limiter Wait: refill 50/s, burst 1 — pace instead of reject ---
+request 1 sent
+request 2 sent
+request 3 sent
+request 4 sent
+request 5 sent
+5 requests paced over at least 80ms — nothing dropped, nothing early
+```
+
+## Code Walkthrough
+
+- `tickerCadence` blocks on `<-ticker.C` before each request: one slot every 20ms, full stop. It's fine for polling loops, but as a limiter it can't absorb bursts (a request arriving just after a tick waits the full interval) and it keeps firing whether or not anyone is consuming.
+- `tokenBucketAllow` builds `rate.NewLimiter(rate.Limit(10), 3)`: tokens drip in at 10/s and the bucket holds at most 3. Five back-to-back `Allow` calls consume the 3 accumulated tokens and reject the other two — deterministically, because at 10/s no meaningful refill happens between consecutive calls. This is the server-side shape: decide *now*, shed what overflows, let the client retry.
+- `tokenBucketWait` flips the policy from rejecting to pacing: `Wait(ctx)` sleeps until a token is available. With refill 50/s and burst 1, the first request goes immediately and each of the next four waits ~20ms, so five requests cannot legally complete in under 80ms. The code asserts that lower bound and prints the *guarantee*, not the raw elapsed time — keeping the output deterministic while still verifying the limiter did its job.
+- `Wait`'s context parameter is the important signature detail: a canceled context or expired deadline aborts the sleep with an error, so a shutting-down service doesn't strand goroutines queueing for tokens.
+
+## Common Pitfalls
+
+- **Confusing rate with burst.** `rate.Limit(10)` bounds the long-run average; `burst` is instantaneous capacity. Burst 1 makes traffic perfectly smooth but brutal on spikes; a larger burst forgives clumps of requests while keeping the same average. Most misconfigured limiters got only one of the two right.
+- **Using `Wait` where you needed `Allow` (or vice versa).** `Wait` inside a request handler queues work invisibly under overload — latency balloons and nothing says why. Servers usually want `Allow` + 429; clients respecting someone else's quota want `Wait`.
+- **One global limiter when the quota is per-key.** A per-user or per-API-key quota needs a limiter per key (a map guarded by a mutex, with eviction); one shared bucket lets a single noisy client starve everyone.
+- **Forgetting `ticker.Stop()`.** A leaked ticker keeps its goroutine and channel alive for the life of the process. (`defer ticker.Stop()` — same discipline as closing a body.)
+- **Testing limiters by asserting exact durations.** Wall-clock assertions flake under load. Assert structural guarantees (at least N tokens' worth of time passed; no more than burst succeeded instantly), or inject a fake clock.
+
+## References
+
+- [golang.org/x/time/rate package docs](https://pkg.go.dev/golang.org/x/time/rate)
+- [Go Wiki — Rate Limiting](https://go.dev/wiki/RateLimiting)
+- [time package docs — Ticker](https://pkg.go.dev/time#Ticker)
+
+## Next Steps
+
+- [concurrency/worker-pool](../worker-pool/) — bounding *concurrency* instead of *rate*; the two compose
+- [http-client](../http-client/) — retries with backoff, the client-side companion to respecting quotas
+- [context](../context/) — the cancellation semantics `Wait` builds on

--- a/examples/concurrency/rate-limiting/go.mod
+++ b/examples/concurrency/rate-limiting/go.mod
@@ -1,0 +1,5 @@
+module github.com/adnvilla/go-examples/examples/concurrency/rate-limiting
+
+go 1.25.0
+
+require golang.org/x/time v0.15.0

--- a/examples/concurrency/rate-limiting/go.sum
+++ b/examples/concurrency/rate-limiting/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=

--- a/examples/concurrency/rate-limiting/main.go
+++ b/examples/concurrency/rate-limiting/main.go
@@ -1,0 +1,92 @@
+// Demonstrates rate limiting: a time.Ticker as a fixed-cadence limiter, and
+// golang.org/x/time/rate's token bucket for the real thing — Allow for
+// shed-load-now decisions and Wait for pacing work without dropping it.
+// Rate limiting is how clients respect API quotas and servers survive bursts.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tickerCadence()
+	tokenBucketAllow()
+	return tokenBucketWait(ctx)
+}
+
+// tickerCadence is the simplest limiter: one request per tick. It works, but
+// it's rigid — no bursts, one token "capacity", and a stopped consumer still
+// has the ticker firing into a buffered channel of size 1.
+func tickerCadence() {
+	fmt.Println("--- time.Ticker: fixed cadence, one request per tick ---")
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	for req := 1; req <= 4; req++ {
+		<-ticker.C // block until the next slot opens
+		fmt.Printf("request %d processed on its tick\n", req)
+	}
+}
+
+// tokenBucketAllow shows the load-shedding side of x/time/rate: Allow takes a
+// token if one is available and reports the decision immediately — the shape
+// used inside servers that answer 429 instead of queueing.
+func tokenBucketAllow() {
+	fmt.Println("\n--- rate.Limiter Allow: refill 10/s, burst 3 — shed what overflows ---")
+	// burst is the bucket size: up to 3 tokens can accumulate, so 3 back-to-
+	// back requests succeed even though the steady-state rate is 10/s.
+	limiter := rate.NewLimiter(rate.Limit(10), 3)
+
+	for req := 1; req <= 5; req++ {
+		if limiter.Allow() {
+			fmt.Printf("request %d: allowed (token consumed)\n", req)
+		} else {
+			fmt.Printf("request %d: rejected — bucket empty, a real server would answer 429\n", req)
+		}
+	}
+}
+
+// tokenBucketWait shows the pacing side: Wait blocks until a token is
+// available (or the context ends), so nothing is dropped — the shape used by
+// clients staying under a provider's quota.
+func tokenBucketWait(ctx context.Context) error {
+	fmt.Println("\n--- rate.Limiter Wait: refill 50/s, burst 1 — pace instead of reject ---")
+	limiter := rate.NewLimiter(rate.Limit(50), 1)
+
+	const requests = 5
+	start := time.Now()
+	for req := 1; req <= requests; req++ {
+		// Wait is where context integration pays off: cancellation or a
+		// deadline aborts the sleep with an error instead of hanging.
+		if err := limiter.Wait(ctx); err != nil {
+			return fmt.Errorf("waiting for token (request %d): %w", req, err)
+		}
+		fmt.Printf("request %d sent\n", req)
+	}
+
+	// At 50 tokens/s with burst 1, requests 2..5 each wait ~20ms, so the loop
+	// cannot legally finish faster than ~80ms. Verify the pacing actually
+	// happened rather than printing machine-dependent timings.
+	elapsed := time.Since(start)
+	minExpected := time.Duration(requests-1) * 20 * time.Millisecond
+	if elapsed < minExpected {
+		return fmt.Errorf("pacing violated: %d requests in %v (< %v)", requests, elapsed, minExpected)
+	}
+	fmt.Printf("%d requests paced over at least %v — nothing dropped, nothing early\n", requests, minExpected)
+	return nil
+}

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@ use (
 	./examples/channels
 	./examples/concurrency/fan-out-timeout
 	./examples/concurrency/pipeline
+	./examples/concurrency/rate-limiting
 	./examples/concurrency/scatter-gather
 	./examples/concurrency/worker-pool
 	./examples/config


### PR DESCRIPTION
## Summary
- New standalone-module example contrasting the two standard rate-limiting approaches, third of the Phase 2 additions
- `time.Ticker` as a rigid fixed-cadence limiter, then `x/time/rate`'s token bucket in both modes: `Allow` for server-side load shedding (burst of 3 absorbed, overflow rejected — deterministic because no meaningful refill happens between back-to-back calls) and `Wait(ctx)` for client-side pacing under a quota
- The pacing demo asserts its structural guarantee (5 requests at 50/s burst 1 cannot finish in under 80ms) and prints the guarantee rather than machine-dependent timings — output stays deterministic
- Dependency justified: `golang.org/x/time` is the canonical limiter package and the topic itself
- Registered in `go.work` and the root README index (Concurrency section)

## Test plan
- [x] `make run EXAMPLE=concurrency/rate-limiting` — output matches the README exactly
- [x] `make check EXAMPLE=concurrency/rate-limiting` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)