### PR TITLE
Add os-exec example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [config](examples/config/) | Reading JSON config with `encoding/json` |
 | [datetime-parse](examples/datetime-parse/) | Parsing dates in multiple formats |
 | [flags](examples/flags/) | Command-line flags with `flag` |
+| [os-exec](examples/os-exec/) | Run external processes: capture output, stdin, exit codes, env, kill on timeout |
 
 ---
 

--- a/examples/os-exec/Makefile
+++ b/examples/os-exec/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/os-exec/README.md
+++ b/examples/os-exec/README.md
@@ -1,0 +1,87 @@
+# os/exec
+
+**Category:** cli
+**Difficulty:** Intermediate
+
+## Objective
+
+Show the five things every program that shells out needs from `os/exec`: capturing a child's output, feeding its stdin, reading its exit code (and telling "ran and failed" apart from "never ran"), controlling its environment, and killing it when a context deadline expires. This is the plumbing behind build tools, git wrappers, and anything that orchestrates other binaries.
+
+## Concepts Covered
+
+- `exec.CommandContext` — always preferred over `exec.Command`: the context is what lets you kill a runaway child
+- `Output()` vs `CombinedOutput()` — keeping stderr separate so warnings don't corrupt parsed output
+- `cmd.Stdin` accepting any `io.Reader` — piping data into a child
+- `*exec.ExitError` via `errors.As` — the exit code lives there, and its absence means the command never started (bad path, permissions)
+- `cmd.Env` replacing (not extending) the inherited environment — the `append(os.Environ(), ...)` idiom
+- Verifying the kill structurally: the 30-second sleep must die near the 200ms deadline
+
+## Prerequisites
+
+- Go 1.24+
+- A Unix-like system (`echo`, `tr`, `sh`, `sleep` on `PATH` — macOS and Linux both qualify; this matches the repo's CI)
+
+## Project Structure
+
+```
+os-exec/
+├── go.mod
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+--- Output: run and capture stdout ---
+captured: "hello from a child process"
+
+--- Stdin: pipe data into the child ---
+tr said: "SHOUT THIS"
+
+--- ExitError: read the child's exit code ---
+command failed as expected with exit code 3
+
+--- Env: control what the child sees ---
+child saw: "greeting is: hola"
+
+--- CommandContext: kill a runaway child ---
+30s sleep killed after the 200ms deadline (context: context deadline exceeded, child: signal: killed)
+```
+
+## Code Walkthrough
+
+- `captureOutput` uses `.Output()`, which runs the command to completion and returns stdout only. Reach for `CombinedOutput` when you want everything a human would see, but never when you intend to *parse* the result — one deprecation warning on stderr and your parser breaks.
+- `feedStdin` assigns `strings.NewReader` to `cmd.Stdin`; the child (`tr a-z A-Z`) reads it exactly as if it were a terminal pipe. Because `Stdin` is an `io.Reader`, files, network connections, or another command's `StdoutPipe` slot in without ceremony — the same composability shown in [io-readers-writers](../io-readers-writers/).
+- `readExitCode` is the error-handling core: `Run()` returning an `*exec.ExitError` means the process started and exited non-zero — `ExitCode()` carries the tool's verdict (here `3`). Any *other* error means the process never ran at all. `errors.As` is what separates the two; treating them the same throws away the difference between "tests failed" and "go not installed".
+- `controlEnvironment` demonstrates the `cmd.Env` trap and its idiom in one line: setting `Env` **replaces** the whole environment, so the child would lose `PATH` and everything else unless you start from `os.Environ()` and append your overrides.
+- `killOnTimeout` wraps the command in a 200ms context and runs `sleep 30`. When the deadline fires, `CommandContext` sends SIGKILL; the demo asserts the elapsed time proves the kill happened rather than trusting the error message. `context.Cause` reports *why* (deadline exceeded) while the command's own error reports *how* (`signal: killed`).
+
+## Common Pitfalls
+
+- **Building shell strings instead of argument lists.** `exec.Command("sh", "-c", "ls "+userInput)` is command injection. Pass arguments as separate parameters — `exec.Command("ls", userInput)` — and the child gets them verbatim, unparsed. (This example uses `sh -c` only with fixed, constant strings.)
+- **`exec.Command` without a context for anything that can hang.** A child blocked on a dead network mount blocks your program forever; `CommandContext` is the same call with an exit strategy.
+- **Setting `cmd.Env` to just your variables.** You silently wiped `PATH`, `HOME`, `TMPDIR`... and the failure shows up as "executable not found" somewhere downstream. Always `append(os.Environ(), ...)` unless isolation is the goal.
+- **Parsing `CombinedOutput`.** Stderr interleaves with stdout nondeterministically. Parse `Output()`, log stderr (available on the `ExitError.Stderr` field when using `Output`).
+- **Forgetting that SIGKILL gives the child no chance to clean up.** `CommandContext`'s default is a hard kill; children that need graceful shutdown want `cmd.Cancel`/`cmd.WaitDelay` (Go 1.20+) to send SIGTERM first and escalate.
+
+## References
+
+- [os/exec package docs](https://pkg.go.dev/os/exec)
+- [os/exec docs — CommandContext, Cancel, WaitDelay](https://pkg.go.dev/os/exec#Cmd)
+- [Go Blog — Command PATH security in Go](https://go.dev/blog/path-security)
+
+## Next Steps
+
+- [context](../context/) — the deadline machinery that kills the runaway child
+- [io-readers-writers](../io-readers-writers/) — the reader/writer seams `cmd.Stdin`/`cmd.Stdout` are built on
+- [graceful-shutdown-signals](../graceful-shutdown-signals/) — signals from the receiving side

--- a/examples/os-exec/go.mod
+++ b/examples/os-exec/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/os-exec
+
+go 1.25.0

--- a/examples/os-exec/main.go
+++ b/examples/os-exec/main.go
@@ -1,0 +1,124 @@
+// Demonstrates running external processes with os/exec: capturing output,
+// feeding stdin, reading exit codes with errors.As, controlling the child's
+// environment, and killing a runaway process via context timeout — the
+// plumbing behind every Go tool that shells out.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := captureOutput(ctx); err != nil {
+		return err
+	}
+	if err := feedStdin(ctx); err != nil {
+		return err
+	}
+	if err := readExitCode(ctx); err != nil {
+		return err
+	}
+	if err := controlEnvironment(ctx); err != nil {
+		return err
+	}
+	return killOnTimeout(ctx)
+}
+
+// captureOutput runs a command and collects its stdout. Output (as opposed to
+// CombinedOutput) keeps stderr separate — mixing them makes output unparseable
+// the day the tool prints a warning.
+func captureOutput(ctx context.Context) error {
+	fmt.Println("--- Output: run and capture stdout ---")
+	out, err := exec.CommandContext(ctx, "echo", "hello from a child process").Output()
+	if err != nil {
+		return fmt.Errorf("running echo: %w", err)
+	}
+	fmt.Printf("captured: %q\n", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// feedStdin pipes data into the child's stdin — here `tr` upper-cases it.
+// Any io.Reader works: a file, a network stream, another command's output.
+func feedStdin(ctx context.Context) error {
+	fmt.Println("\n--- Stdin: pipe data into the child ---")
+	cmd := exec.CommandContext(ctx, "tr", "a-z", "A-Z")
+	cmd.Stdin = strings.NewReader("shout this\n")
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("running tr: %w", err)
+	}
+	fmt.Printf("tr said: %q\n", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// readExitCode distinguishes "the command ran and failed" (*exec.ExitError,
+// carries the exit code) from "the command never ran" (bad path, permissions).
+// Tools speak through exit codes; conflating the two cases loses that signal.
+func readExitCode(ctx context.Context) error {
+	fmt.Println("\n--- ExitError: read the child's exit code ---")
+	err := exec.CommandContext(ctx, "sh", "-c", "exit 3").Run()
+
+	var exitErr *exec.ExitError
+	switch {
+	case errors.As(err, &exitErr):
+		fmt.Printf("command failed as expected with exit code %d\n", exitErr.ExitCode())
+	case err != nil:
+		return fmt.Errorf("command could not start: %w", err)
+	default:
+		return errors.New("expected a non-zero exit, got success")
+	}
+	return nil
+}
+
+// controlEnvironment sets the child's env explicitly. Setting cmd.Env replaces
+// the inherited environment entirely — start from os.Environ() and append,
+// or the child loses PATH, HOME, and friends.
+func controlEnvironment(ctx context.Context) error {
+	fmt.Println("\n--- Env: control what the child sees ---")
+	cmd := exec.CommandContext(ctx, "sh", "-c", `echo "greeting is: $GREETING"`)
+	cmd.Env = append(os.Environ(), "GREETING=hola")
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("running env demo: %w", err)
+	}
+	fmt.Printf("child saw: %q\n", strings.TrimSpace(string(out)))
+	return nil
+}
+
+// killOnTimeout shows CommandContext's reason for existing: when the context
+// expires, the child is killed instead of hanging the parent forever.
+func killOnTimeout(ctx context.Context) error {
+	fmt.Println("\n--- CommandContext: kill a runaway child ---")
+	timeoutCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := exec.CommandContext(timeoutCtx, "sleep", "30").Run()
+	elapsed := time.Since(start)
+
+	if err == nil {
+		return errors.New("expected the 30s sleep to be killed, but it finished")
+	}
+	if elapsed >= 30*time.Second {
+		return fmt.Errorf("child was not killed by the deadline (took %v)", elapsed)
+	}
+	fmt.Printf("30s sleep killed after the 200ms deadline (context: %v, child: %v)\n",
+		context.Cause(timeoutCtx), err)
+	return nil
+}

--- a/go.work
+++ b/go.work
@@ -33,6 +33,7 @@ use (
 	./examples/mysql
 	./examples/oop
 	./examples/oop/composition
+	./examples/os-exec
 	./examples/otel
 	./examples/pool
 	./examples/profiling


### PR DESCRIPTION
## Summary
- New standalone-module example for `os/exec`, first of the final low-priority batch
- Five demos: `Output()` capture (and why not `CombinedOutput` for parsing), stdin from any `io.Reader`, exit codes via `errors.As(*exec.ExitError)` distinguishing ran-and-failed from never-ran, the `cmd.Env` replaces-not-extends trap with the `append(os.Environ(), ...)` idiom, and `CommandContext` killing a 30s `sleep` at a 200ms deadline — asserted by elapsed time, not the error string
- README pitfalls cover command injection (`sh -c` + user input), SIGKILL vs `cmd.Cancel`/`WaitDelay` graceful termination
- Uses only POSIX tools (`echo`, `tr`, `sh`, `sleep`) present on macOS and the Ubuntu CI runners; no dependencies

## Test plan
- [x] `make run EXAMPLE=os-exec` — output matches the README exactly
- [x] `make check EXAMPLE=os-exec` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)