### PR TITLE
Add templates example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [datetime-parse](examples/datetime-parse/) | Parsing dates in multiple formats |
 | [flags](examples/flags/) | Command-line flags with `flag` |
 | [os-exec](examples/os-exec/) | Run external processes: capture output, stdin, exit codes, env, kill on timeout |
+| [templates](examples/templates/) | `text/template` vs `html/template`: actions, FuncMap, composition, auto-escaping |
 
 ---
 

--- a/examples/templates/Makefile
+++ b/examples/templates/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -1,0 +1,85 @@
+# Templates
+
+**Category:** basics
+**Difficulty:** Beginner
+
+## Objective
+
+Show Go's two template packages and the one difference that matters between them: `text/template` renders data into any text format (reports, config files, generated code), while `html/template` offers the *same API* plus contextual auto-escaping, so untrusted data can't break out of the HTML structure. Along the way: actions (`range`, `if`), custom functions via `FuncMap`, whitespace trimming, and composing documents from named blocks with `define`/`template`.
+
+## Concepts Covered
+
+- Template actions: `{{.Field}}`, `{{range}}`, `{{if}}/{{else}}`, `gt`/`len` built-ins
+- `FuncMap` — registering custom functions (`upper`, a currency formatter) callable from template source
+- `{{-` / `-}}` trim markers — keeping template-source formatting out of the rendered output
+- `define` + `template` — named blocks and partials, the mechanism behind layout/page structures
+- `html/template`'s contextual auto-escaping, demonstrated by pushing the same `<script>` payload through both packages
+- Templates render to any `io.Writer` — stdout here, `http.ResponseWriter` or files in real programs
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+templates/
+├── go.mod
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+```
+--- text/template: report with range, if, and FuncMap ---
+Invoice for ADA
+- keyboard: 89.90 EUR (12 in stock)
+- trackball: 54.50 EUR (SOLD OUT)
+- desk mat: 19.00 EUR (3 in stock)
+
+--- composition: define / template ---
+== Order Summary ==
+customer: Ada, items: 3
+
+--- html/template: contextual auto-escaping ---
+text/template: <p>comment from mallory: <script>alert("pwned")</script></p>
+html/template: <p>comment from mallory: &lt;script&gt;alert(&#34;pwned&#34;)&lt;/script&gt;</p>
+```
+
+## Code Walkthrough
+
+- `textReport` covers the daily-driver features in one template: `.Customer` field access, `{{range .Items}}` iterating the slice (inside the loop, `.` becomes the current item), `{{if gt .Stock 0}}` branching on data, and two `FuncMap` functions — note `Funcs` must be called *before* `Parse`, since parsing validates that every function referenced exists.
+- The `{{-` and `-}}` markers trim adjacent whitespace and newlines. Without them, the line breaks that make the template source readable leak into the output as blank lines — compare the source's layout with the rendered invoice.
+- `composedTemplates` builds a document from named blocks: `define "header"` declares a partial, and `{{template "header" "Order Summary"}}` invokes it with its own data (a plain string here — whatever you pass becomes the partial's `.`). `ExecuteTemplate` picks the entry point by name. This is the exact mechanism web apps use for layout + page templates, usually loading many files at once with `template.ParseFS` over an embedded filesystem (see [embed](../embed/)).
+- `escapingContrast` is the security punchline. The template source is *identical* for both packages; only the import changes. `text/template` reproduces mallory's `<script>` verbatim — fine for a text report, an XSS hole in a web page. `html/template` parses the surrounding markup, understands the value lands in HTML text content, and escapes accordingly. The escaping is *contextual*: the same value placed inside an attribute, a URL, or a `<script>` block gets that context's rules, not one-size-fits-all entity encoding.
+
+## Common Pitfalls
+
+- **Using `text/template` to produce HTML.** The API is identical, so nothing warns you — until user input renders as markup. If the output is HTML, import `html/template`; the type system then also distinguishes pre-trusted fragments (`template.HTML`) from plain strings.
+- **Wrapping untrusted input in `template.HTML` to "fix" escaping.** That type is an assertion that *you* already sanitized the value; applying it to user input reintroduces exactly the XSS the package prevents.
+- **Calling `.Funcs` after `.Parse`.** Parse fails with `function "x" not defined` — registration must precede parsing because the parser checks the function table.
+- **Ranging over a map when output must be stable.** Map iteration order is randomized (`text/template` sorts keys only for basic types); prefer slices when order matters, as this example does.
+- **Ignoring `Execute`'s error.** Templates fail at render time too (nil field access, a FuncMap function returning an error) — and with an `http.ResponseWriter`, a partial page may already be written; render to a buffer first when you need all-or-nothing pages.
+
+## References
+
+- [text/template package docs](https://pkg.go.dev/text/template)
+- [html/template package docs](https://pkg.go.dev/html/template)
+- [html/template — security model](https://pkg.go.dev/html/template#hdr-Introduction)
+
+## Next Steps
+
+- [embed](../embed/) — `//go:embed` + `template.ParseFS`, how real projects ship template files
+- [http-server](../http-server/) — where HTML templates typically get executed
+- [io-readers-writers](../io-readers-writers/) — the `io.Writer` seam templates render into

--- a/examples/templates/go.mod
+++ b/examples/templates/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/templates
+
+go 1.25.0

--- a/examples/templates/main.go
+++ b/examples/templates/main.go
@@ -1,0 +1,143 @@
+// Demonstrates Go's two template packages and the one difference that
+// matters: text/template renders data into any text format (reports, config,
+// code), while html/template has the same API plus contextual auto-escaping —
+// untrusted data cannot break out of the HTML structure. Also covers actions
+// (range, if), custom functions via FuncMap, and composing templates with
+// define/template.
+package main
+
+import (
+	"fmt"
+	htmltemplate "html/template"
+	"os"
+	"strings"
+	texttemplate "text/template"
+)
+
+type Item struct {
+	Name  string
+	Price float64
+	Stock int
+}
+
+type Order struct {
+	Customer string
+	Items    []Item
+}
+
+var order = Order{
+	Customer: "Ada",
+	Items: []Item{
+		{Name: "keyboard", Price: 89.90, Stock: 12},
+		{Name: "trackball", Price: 54.50, Stock: 0},
+		{Name: "desk mat", Price: 19.00, Stock: 3},
+	},
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	if err := textReport(); err != nil {
+		return err
+	}
+	if err := composedTemplates(); err != nil {
+		return err
+	}
+	return escapingContrast()
+}
+
+// textReport renders a plain-text invoice: field access, range with $-scoped
+// outer variables, if/else on data, and two custom functions registered
+// through FuncMap. The `-` trim markers eat the newlines that template
+// source formatting would otherwise leak into the output.
+func textReport() error {
+	fmt.Println("--- text/template: report with range, if, and FuncMap ---")
+
+	funcs := texttemplate.FuncMap{
+		"upper": strings.ToUpper,
+		"eur":   func(v float64) string { return fmt.Sprintf("%.2f EUR", v) },
+	}
+
+	const src = `Invoice for {{upper .Customer}}
+{{- range .Items}}
+- {{.Name}}: {{eur .Price}} {{if gt .Stock 0}}({{.Stock}} in stock){{else}}(SOLD OUT){{end}}
+{{- end}}
+`
+	tmpl, err := texttemplate.New("invoice").Funcs(funcs).Parse(src)
+	if err != nil {
+		return fmt.Errorf("parsing invoice template: %w", err)
+	}
+	if err := tmpl.Execute(os.Stdout, order); err != nil {
+		return fmt.Errorf("rendering invoice: %w", err)
+	}
+	return nil
+}
+
+// composedTemplates splits a document into named blocks: a layout that
+// {{template}}s a header partial. Real projects parse many files this way
+// (template.ParseFS pairs naturally with //go:embed).
+func composedTemplates() error {
+	fmt.Println("\n--- composition: define / template ---")
+
+	const src = `
+{{- define "header" -}}
+== {{.}} ==
+{{- end -}}
+
+{{- define "page" -}}
+{{template "header" "Order Summary"}}
+customer: {{.Customer}}, items: {{len .Items}}
+{{- end -}}`
+
+	tmpl, err := texttemplate.New("doc").Parse(src)
+	if err != nil {
+		return fmt.Errorf("parsing composed templates: %w", err)
+	}
+	if err := tmpl.ExecuteTemplate(os.Stdout, "page", order); err != nil {
+		return fmt.Errorf("rendering page: %w", err)
+	}
+	fmt.Println()
+	return nil
+}
+
+// escapingContrast pushes the same hostile input through both packages.
+// text/template reproduces it verbatim; html/template escapes it according
+// to where it lands in the markup, neutralizing the script injection.
+func escapingContrast() error {
+	fmt.Println("\n--- html/template: contextual auto-escaping ---")
+
+	const src = `<p>comment from {{.User}}: {{.Comment}}</p>`
+	hostile := struct {
+		User    string
+		Comment string
+	}{
+		User:    "mallory",
+		Comment: `<script>alert("pwned")</script>`,
+	}
+
+	textTmpl, err := texttemplate.New("raw").Parse(src)
+	if err != nil {
+		return fmt.Errorf("parsing text version: %w", err)
+	}
+	fmt.Print("text/template: ")
+	if err := textTmpl.Execute(os.Stdout, hostile); err != nil {
+		return fmt.Errorf("rendering text version: %w", err)
+	}
+	fmt.Println()
+
+	htmlTmpl, err := htmltemplate.New("safe").Parse(src)
+	if err != nil {
+		return fmt.Errorf("parsing html version: %w", err)
+	}
+	fmt.Print("html/template: ")
+	if err := htmlTmpl.Execute(os.Stdout, hostile); err != nil {
+		return fmt.Errorf("rendering html version: %w", err)
+	}
+	fmt.Println()
+	return nil
+}

--- a/go.work
+++ b/go.work
@@ -46,6 +46,7 @@ use (
 	./examples/slog
 	./examples/sqlite
 	./examples/sync-primitives
+	./examples/templates
 	./examples/testing-patterns
 	./examples/typecast
 	./examples/wire


### PR DESCRIPTION
## Summary
- New standalone-module example for Go's template packages, second of the final batch
- Three demos: a plain-text invoice exercising `range`/`if`/`gt` plus two `FuncMap` functions and whitespace trim markers; `define`/`template` composition with `ExecuteTemplate` (the layout/partial mechanism); and the security punchline — identical template source with a hostile `<script>` payload rendered verbatim by `text/template` and contextually escaped by `html/template`
- README pitfalls cover the `template.HTML` misuse trap, `Funcs`-before-`Parse`, map iteration order, and buffering before writing to an `http.ResponseWriter`
- No dependencies; deterministic output; registered in `go.work` and the root README index

## Test plan
- [x] `make run EXAMPLE=templates` — output matches the README exactly
- [x] `make check EXAMPLE=templates` (build, vet, test, lint, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)