### PR TITLE
Add crypto-basics example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ A collection of Go examples organized by topic. Requires Go 1.24+.
 | [serialization](examples/serialization/) | Flexible JSON: field that is either an object or array |
 | [protobuf](examples/protobuf/) | Binary serialization with Protocol Buffers |
 
+### Security
+
+| Directory | Description |
+|-----------|-------------|
+| [crypto-basics](examples/crypto-basics/) | `sha256`, HMAC + constant-time compare, `crypto/rand` tokens, AES-GCM |
+
 ### Cloud & Infrastructure
 
 | Directory | Description |

--- a/examples/crypto-basics/Makefile
+++ b/examples/crypto-basics/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/crypto-basics/README.md
+++ b/examples/crypto-basics/README.md
@@ -1,0 +1,93 @@
+# Crypto Basics
+
+**Category:** security
+**Difficulty:** Intermediate
+
+## Objective
+
+Show the four crypto building blocks every backend eventually needs, using only the standard library: `sha256` content fingerprints, HMAC message authentication with constant-time verification, `crypto/rand` for unpredictable tokens, and AES-GCM authenticated encryption — including the demonstration that tampering with one bit of ciphertext makes decryption *fail* instead of returning garbage.
+
+## Concepts Covered
+
+- `sha256.Sum256` — deterministic, one-way fingerprints with the avalanche effect (one changed character rewrites the digest), and why fast hashes are **not** for passwords
+- `hmac.New(sha256.New, key)` + `hmac.Equal` — signing a message with a shared secret and verifying in constant time (no timing side channel)
+- `crypto/rand.Read` — the unpredictable source for session ids, API keys, and nonces (`math/rand` is for simulations, never secrets)
+- AES-256-GCM via `cipher.NewGCM` — confidentiality and integrity in one primitive; `Seal`/`Open`, the prepended-nonce convention, and authenticated rejection of tampered ciphertexts
+- Key hygiene signposting: demo key derived from a string with a loud comment; real keys come from a KDF (argon2/scrypt) or a secrets manager
+
+## Prerequisites
+
+- Go 1.24+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+crypto-basics/
+├── go.mod
+├── main.go
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+# or
+go run .
+```
+
+## Expected Output
+
+Digest and tag lines are deterministic; the random token and the GCM nonce differ every run (marked below):
+
+```
+--- sha256: content fingerprints ---
+sha256("the quick brown fox") = 9ecb36561341d18eb65484e833efea61edc74b84cf5e6ae1b81c63533e25fc8f
+sha256("the quick brown fix") = 08b6e30107c526b3fcd635de9b011e0ee90c46190168c3e578532eb7c61f69e5
+
+--- hmac-sha256: authenticate a message ---
+message: {"amount": 100, "to": "alice"}
+tag:     e39792c118e73302f7e5aa38b2c1304d76152332f39125fe05826d1489e97e29
+genuine message accepted: true
+tampered message accepted: false
+
+--- crypto/rand: unpredictable tokens ---
+32-byte token, base64url encoded (differs every run): <varies>
+
+--- aes-gcm: authenticated encryption ---
+plaintext 16 bytes -> sealed 44 bytes (12 nonce + 16 ciphertext + 16 tag)
+decrypted matches original: true
+tampered ciphertext rejected: cipher: message authentication failed
+```
+
+## Code Walkthrough
+
+- `hashing` fingerprints two strings that differ by one character — the completely unrelated digests are the avalanche effect, which is what makes hashes useful as content addresses and integrity checks. The comment says the quiet part loudly: sha256 is *fast*, and fast is exactly wrong for passwords, where the attacker's cost per guess is the defense (use bcrypt/scrypt/argon2).
+- `messageAuthentication` shows why HMAC exists: the tag proves the message came from someone holding the key *and* wasn't modified. Verification recomputes the tag and compares with `hmac.Equal` — constant-time, so response timing doesn't leak how many leading bytes matched. The tampered `{"amount": 9999}` message is rejected while the genuine one passes.
+- `randomTokens` reads 32 bytes from `crypto/rand` and base64url-encodes them — the standard recipe for session ids and API keys. The error check on `rand.Read` matters in principle (an unreadable entropy source is a stop-the-world problem, not one to paper over).
+- `authenticatedEncryption` runs the full AES-GCM lifecycle: derive a (demo) 32-byte key, generate a fresh random nonce, `Seal`, then `Open`. Passing `nonce` as `Seal`'s first argument prepends it to the output — the standard way to ship nonce+ciphertext+tag as one blob, since the nonce isn't secret, it just must never repeat under the same key. Flipping one ciphertext bit makes `Open` return `cipher: message authentication failed` — GCM authenticates before it decrypts, which is why modern designs use AEAD instead of bare CBC/CTR plus hope.
+
+## Common Pitfalls
+
+- **Hashing passwords with sha256 (even salted).** GPUs try billions of sha256 guesses per second. Password storage needs a deliberately slow, memory-hard KDF: argon2id or scrypt (`golang.org/x/crypto`), or bcrypt.
+- **Comparing secrets with `==` or `bytes.Equal`.** Both short-circuit on the first differing byte, leaking match length through timing. Use `hmac.Equal` / `subtle.ConstantTimeCompare` for tags, tokens, and API keys.
+- **`math/rand` for anything secret.** It's seeded and predictable by design. `crypto/rand` is the only source for keys, tokens, and nonces.
+- **Reusing a GCM nonce under the same key.** Two messages sealed with the same key+nonce break the scheme catastrophically (keystream reuse, forgeable tags). Random 12-byte nonces are fine for bounded message counts; high-volume systems use counters or rotate keys.
+- **Encrypting without authentication.** Bare AES-CTR/CBC returns *something* for tampered input, and downstream code parses it. AEAD modes like GCM fail closed — prefer them always; there is essentially no reason to hand-roll encrypt-then-MAC today.
+- **Hardcoding keys in source.** The demo derives its key from a string and says so in a comment; production keys live in a KMS/secrets manager and reach the process as bytes, not literals.
+
+## References
+
+- [crypto/sha256 package docs](https://pkg.go.dev/crypto/sha256)
+- [crypto/hmac package docs](https://pkg.go.dev/crypto/hmac)
+- [crypto/cipher package docs — AEAD](https://pkg.go.dev/crypto/cipher#AEAD)
+- [crypto/rand package docs](https://pkg.go.dev/crypto/rand)
+- [golang.org/x/crypto/argon2](https://pkg.go.dev/golang.org/x/crypto/argon2) — for the password-hashing case this example deliberately excludes
+
+## Next Steps
+
+- [errors](../errors/) — the wrapping discipline used on every failure path here
+- [io-readers-writers](../io-readers-writers/) — `io.TeeReader` + `sha256` for hashing streams in one pass
+- [http-server](../http-server/) — where HMAC-signed payloads (webhooks) typically arrive

--- a/examples/crypto-basics/go.mod
+++ b/examples/crypto-basics/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/crypto-basics
+
+go 1.25.0

--- a/examples/crypto-basics/main.go
+++ b/examples/crypto-basics/main.go
@@ -1,0 +1,130 @@
+// Demonstrates the crypto building blocks every backend eventually needs,
+// stdlib only: sha256 content hashing, HMAC message authentication with
+// constant-time verification, crypto/rand for unpredictable tokens, and
+// AES-GCM authenticated encryption — including what happens when a
+// ciphertext is tampered with.
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	hashing()
+	messageAuthentication()
+	if err := randomTokens(); err != nil {
+		return err
+	}
+	return authenticatedEncryption()
+}
+
+// hashing shows sha256 as a content fingerprint: deterministic, one-way, and
+// avalanche — a one-character change rewrites the whole digest. NOT for
+// passwords (those need a slow KDF: bcrypt/scrypt/argon2).
+func hashing() {
+	fmt.Println("--- sha256: content fingerprints ---")
+	digest := sha256.Sum256([]byte("the quick brown fox"))
+	fmt.Printf("sha256(\"the quick brown fox\") = %x\n", digest)
+
+	changed := sha256.Sum256([]byte("the quick brown fix"))
+	fmt.Printf("sha256(\"the quick brown fix\") = %x\n", changed)
+}
+
+// messageAuthentication signs a message with HMAC-SHA256 and verifies it with
+// hmac.Equal — which compares in constant time, so attackers can't binary-
+// search the tag byte by byte through response timings.
+func messageAuthentication() {
+	fmt.Println("\n--- hmac-sha256: authenticate a message ---")
+	key := []byte("shared secret between the two parties")
+	message := []byte(`{"amount": 100, "to": "alice"}`)
+
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(message) // hash.Hash writes never return an error
+	tag := mac.Sum(nil)
+	fmt.Printf("message: %s\ntag:     %x\n", message, tag)
+
+	fmt.Println("genuine message accepted:", verify(key, message, tag))
+	fmt.Println("tampered message accepted:", verify(key, []byte(`{"amount": 9999, "to": "mallory"}`), tag))
+}
+
+// verify recomputes the tag and compares in constant time.
+func verify(key, message, tag []byte) bool {
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(message)
+	return hmac.Equal(tag, mac.Sum(nil))
+}
+
+// randomTokens draws from crypto/rand — the unpredictable source for session
+// ids, API keys, and nonces. math/rand is for simulations, never for secrets.
+func randomTokens() error {
+	fmt.Println("\n--- crypto/rand: unpredictable tokens ---")
+	token := make([]byte, 32)
+	if _, err := rand.Read(token); err != nil {
+		return fmt.Errorf("reading random bytes: %w", err)
+	}
+	fmt.Printf("32-byte token, base64url encoded (differs every run): %s\n",
+		base64.RawURLEncoding.EncodeToString(token))
+	return nil
+}
+
+// authenticatedEncryption encrypts with AES-256-GCM: confidentiality AND
+// integrity in one primitive. The random nonce is prepended to the ciphertext
+// (it's not secret, it just must never repeat for the same key); tampering
+// with a single byte makes Open fail instead of returning garbage.
+func authenticatedEncryption() error {
+	fmt.Println("\n--- aes-gcm: authenticated encryption ---")
+	// Demo only: a real key comes from a KDF (argon2/scrypt) or a secrets
+	// manager, never from a string in the source.
+	key := sha256.Sum256([]byte("derive real keys with a KDF, not like this"))
+	plaintext := []byte("attack at dawn!!")
+
+	block, err := aes.NewCipher(key[:])
+	if err != nil {
+		return fmt.Errorf("creating cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return fmt.Errorf("creating GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("generating nonce: %w", err)
+	}
+
+	// Seal appends ciphertext+tag to its first argument; passing the nonce
+	// there is the standard trick to ship nonce and ciphertext as one blob.
+	sealed := gcm.Seal(nonce, nonce, plaintext, nil)
+	fmt.Printf("plaintext %d bytes -> sealed %d bytes (12 nonce + %d ciphertext + 16 tag)\n",
+		len(plaintext), len(sealed), len(plaintext))
+
+	nonce, ciphertext := sealed[:gcm.NonceSize()], sealed[gcm.NonceSize():]
+	decrypted, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return fmt.Errorf("decrypting: %w", err)
+	}
+	fmt.Printf("decrypted matches original: %t\n", string(decrypted) == string(plaintext))
+
+	// Flip one bit and GCM's authentication rejects the whole message.
+	ciphertext[0] ^= 0x01
+	if _, err := gcm.Open(nil, nonce, ciphertext, nil); err != nil {
+		fmt.Printf("tampered ciphertext rejected: %v\n", err)
+		return nil
+	}
+	return errors.New("tampered ciphertext was accepted — GCM should have rejected it")
+}

--- a/go.work
+++ b/go.work
@@ -10,6 +10,7 @@ use (
 	./examples/concurrency/worker-pool
 	./examples/config
 	./examples/context
+	./examples/crypto-basics
 	./examples/datetime-parse
 	./examples/dynamodb
 	./examples/embed


### PR DESCRIPTION
## Summary
- New standalone-module example for the stdlib crypto building blocks, last new example of the batch — inaugurates a Security section in the root README
- Four demos: `sha256` fingerprints showing the avalanche effect (with the passwords-need-a-KDF warning front and center), HMAC-SHA256 signing with constant-time `hmac.Equal` verification rejecting a tampered `{"amount": 9999}` message, `crypto/rand` tokens, and AES-256-GCM `Seal`/`Open` with the prepended-nonce convention — flipping one ciphertext bit yields `cipher: message authentication failed` instead of garbage
- README pitfalls cover the classics: sha256 for passwords, `==` on secrets (timing leaks), `math/rand` for tokens, GCM nonce reuse, unauthenticated encryption, hardcoded keys
- Stdlib only, passes `gosec`; deterministic output except the token and nonce (marked in the README)

## Test plan
- [x] `make run EXAMPLE=crypto-basics` — digests/tags match the README; tamper paths rejected
- [x] `make check EXAMPLE=crypto-basics` (build, vet, test, lint incl. gosec, fmt) — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)