### PR TITLE
Support Go 1.26 and drop Go 1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.24", "1.25"]
+        go-version: ["1.25", "1.26"]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Check go mod tidy (every workspace module)
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Install golangci-lint v2
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Install govulncheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A collection of standalone Go examples organized by topic (`examples/<topic>/`), each demonstrating one Go feature, pattern, or library integration. There is no shared application, and no shared root module either — every example directory is its own independent Go module (own `go.mod`/`go.sum`), most `package main` (runnable via `go run .`), a few named packages meant to be imported/tested as libraries. The repo root itself has no Go packages; it only holds `go.work` (the workspace listing every example module) and shared tooling (`Makefile`, `.golangci.yml`, `docker-compose.yml`). Requires Go 1.24+ (each module targets `go 1.25.0`).
+A collection of standalone Go examples organized by topic (`examples/<topic>/`), each demonstrating one Go feature, pattern, or library integration. There is no shared application, and no shared root module either — every example directory is its own independent Go module (own `go.mod`/`go.sum`), most `package main` (runnable via `go run .`), a few named packages meant to be imported/tested as libraries. The repo root itself has no Go packages; it only holds `go.work` (the workspace listing every example module) and shared tooling (`Makefile`, `.golangci.yml`, `docker-compose.yml`). Requires Go 1.25+ (each module targets `go 1.25.0`; CI also tests Go 1.26).
 
 ## Commands
 
@@ -55,7 +55,7 @@ New example → `make use EXAMPLE=<name>` (once), then
 
 ### CI enforces build, tidy, lint, and vulnerabilities — not just build/test
 
-`.github/workflows/build.yml` runs four independent jobs on push/PR to `master` (Go 1.24 + 1.25 matrix for the test job only):
+`.github/workflows/build.yml` runs four independent jobs on push/PR to `master` (Go 1.25 + 1.26 matrix for the test job only; the other jobs run on 1.26):
 1. **test** — `go build`, `go vet`, `go test -race -count=1 ./...`
 2. **tidy** — runs `go mod tidy` and fails if `go.mod`/`go.sum` diverge from the committed version
 3. **lint** — `golangci-lint` (v2 config in `.golangci.yml`: `errcheck`, `govet` with all analyzers except `fieldalignment`, `staticcheck`, `unused`, `misspell`, `unconvert`, `gosec`, `bodyclose`, `noctx`, `rowserrcheck`). Several examples (`benchmark`, `mysql`, `reflection-bench`, `protobuf`) have per-path `exclude-rules` in `.golangci.yml` for pre-context-API or deprecated-SDK code predating this repo's current conventions — don't "fix" those without checking why the exclusion exists first. These path-based exclude-rules are resolved relative to the repo root regardless of each example's own module boundary, so they keep working even though every example is its own module.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-examples
 
-A collection of standalone Go examples. Requires Go 1.24+.
+A collection of standalone Go examples. Requires Go 1.25+.
 
 ## Learning path
 

--- a/examples/benchmark/README.md
+++ b/examples/benchmark/README.md
@@ -16,7 +16,7 @@ Show `testing.B` benchmarks used to compare configuration choices empirically â€
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - A running MySQL instance matching this repo's `docker-compose.yml` (`root`/`secret`@`localhost:3306`/`examples`):
   ```bash
   docker compose up -d mysql

--- a/examples/channels/README.md
+++ b/examples/channels/README.md
@@ -17,7 +17,7 @@ Show the minimal pattern for one goroutine producing values and another consumin
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/concurrency/fan-out-timeout/README.md
+++ b/examples/concurrency/fan-out-timeout/README.md
@@ -16,7 +16,7 @@ Show how to bound how long you'll wait for any single goroutine in a fan-out, us
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/concurrency/rate-limiting/README.md
+++ b/examples/concurrency/rate-limiting/README.md
@@ -17,7 +17,7 @@ Show the two standard ways to rate-limit in Go and when each fits: a `time.Ticke
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required — the single dependency (`golang.org/x/time`) is the canonical rate-limiting package and the thing being taught
 
 ## Project Structure

--- a/examples/concurrency/scatter-gather/README.md
+++ b/examples/concurrency/scatter-gather/README.md
@@ -16,7 +16,7 @@ Contrast with the [worker-pool](../worker-pool/) pattern: instead of a fixed num
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/concurrency/worker-pool/README.md
+++ b/examples/concurrency/worker-pool/README.md
@@ -16,7 +16,7 @@ Show the worker pool pattern: a fixed number of goroutines pull jobs off a share
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -15,7 +15,7 @@ Show the minimal pattern for reading a JSON configuration file from disk into a 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services; reads `config.json` from its own directory
 
 ## Project Structure

--- a/examples/context/README.md
+++ b/examples/context/README.md
@@ -18,7 +18,7 @@ Show the three main things `context.Context` is used for in idiomatic Go: cancel
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/crypto-basics/README.md
+++ b/examples/crypto-basics/README.md
@@ -17,7 +17,7 @@ Show the four crypto building blocks every backend eventually needs, using only 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/datetime-parse/README.md
+++ b/examples/datetime-parse/README.md
@@ -16,7 +16,7 @@ Show `github.com/araddon/dateparse` parsing dozens of real-world date/time forma
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/dynamodb/README.md
+++ b/examples/dynamodb/README.md
@@ -19,7 +19,7 @@ Show a full DynamoDB CRUD cycle with AWS SDK v2: create a table, put items (indi
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - A running DynamoDB Local instance (this repo's `docker-compose.yml` provides one on `localhost:8000`):
   ```bash
   docker compose up -d dynamodb

--- a/examples/embed/README.md
+++ b/examples/embed/README.md
@@ -16,7 +16,7 @@ Show the three shapes of `//go:embed`: a single file as a `string`, a single fil
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/errgroup/README.md
+++ b/examples/errgroup/README.md
@@ -16,7 +16,7 @@ Show `golang.org/x/sync/errgroup` replacing the manual `sync.WaitGroup` + shared
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure
@@ -64,7 +64,7 @@ Each `fetch` call's delay is proportional to its `id` (`id*10ms`), and results a
 
 ## Common Pitfalls
 
-- **Forgetting to capture loop variables before Go 1.22.** `i, id := i, id` inside the loop is the classic guard against every goroutine closing over the same shared loop variable — as of Go 1.22 the language changed loop variable semantics to make each iteration's variable distinct, but this repo also runs on Go 1.24/1.25 where it's no longer strictly necessary; it's kept here for clarity and because the pattern is still idiomatic when targeting older Go versions.
+- **Forgetting to capture loop variables before Go 1.22.** `i, id := i, id` inside the loop is the classic guard against every goroutine closing over the same shared loop variable — as of Go 1.22 the language changed loop variable semantics to make each iteration's variable distinct, but this repo also runs on Go 1.25/1.26 where it's no longer strictly necessary; it's kept here for clarity and because the pattern is still idiomatic when targeting older Go versions.
 - **Ignoring the context `errgroup.WithContext` returns.** Using the *original* `ctx` instead of the one returned by `WithContext` means goroutines never see the early-cancellation-on-error behavior — the whole point of using `errgroup` over a plain `WaitGroup` for this use case.
 - **Assuming `g.Wait()` reports every failure.** Only the first error is returned; if you need all errors, collect them explicitly (e.g. via `errors.Join` — see [errors](../errors/)) inside each `g.Go` closure instead of relying on the group's return value.
 - **Setting `SetLimit` too low for the workload.** A limit lower than the number of goroutines that must run concurrently to make progress (e.g. if later tasks depend on earlier ones completing within the same batch) can deadlock — `SetLimit` is for bounding *independent* work, not for scheduling dependent tasks.

--- a/examples/errors/README.md
+++ b/examples/errors/README.md
@@ -16,7 +16,7 @@ Show the standard-library error-handling toolkit: sentinel errors, custom error 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/flags/README.md
+++ b/examples/flags/README.md
@@ -16,7 +16,7 @@ Show the standard-library `flag` package: declaring string/int/bool flags (two d
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/functional-options/README.md
+++ b/examples/functional-options/README.md
@@ -16,7 +16,7 @@ Show how to configure a struct with sensible defaults, letting callers override 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/generics/README.md
+++ b/examples/generics/README.md
@@ -16,7 +16,7 @@ Show what type parameters (Go 1.18+) buy you: collection functions (`Map`/`Filte
 
 ## Prerequisites
 
-- Go 1.24+ (generics require Go 1.18+; this repo targets 1.25)
+- Go 1.25+ (generics require Go 1.18+; this repo targets 1.25)
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/gin/README.md
+++ b/examples/gin/README.md
@@ -16,7 +16,7 @@ Show the smallest possible HTTP API using the [Gin](https://github.com/gin-gonic
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services; listens on `:8080`
 
 ## Project Structure

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -19,7 +19,7 @@ Show a gRPC service end to end from a single `.proto` contract: a unary RPC, a s
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - Nothing extra to *run* it — the generated code is committed
 - To *regenerate* after editing `greeter.proto`: `protoc` plus both Go plugins on `PATH`:
   ```bash

--- a/examples/http-client/README.md
+++ b/examples/http-client/README.md
@@ -18,7 +18,7 @@ Show a production-shaped HTTP client built entirely on the standard library: per
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - **Internet access** — this example makes a real GET request to `https://jsonplaceholder.typicode.com/posts/1`, a public test API. No other setup required.
 
 ## Project Structure

--- a/examples/http-server/README.md
+++ b/examples/http-server/README.md
@@ -17,7 +17,7 @@ Show a production-shaped HTTP server built entirely on the standard library: a m
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services; listens on `:8080`
 
 ## Project Structure

--- a/examples/httptest/README.md
+++ b/examples/httptest/README.md
@@ -17,7 +17,7 @@ Show the two halves of `net/http/httptest` and when each applies: `httptest.NewR
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/inject/README.md
+++ b/examples/inject/README.md
@@ -16,7 +16,7 @@ Show idiomatic Go dependency injection: passing interfaces into constructors exp
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/io-readers-writers/README.md
+++ b/examples/io-readers-writers/README.md
@@ -19,7 +19,7 @@ Show the `io.Reader`/`io.Writer` contract — the two one-method interfaces that
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/iterator/README.md
+++ b/examples/iterator/README.md
@@ -17,7 +17,7 @@ Show range-over-func iterators (Go 1.23+): functions matching `iter.Seq[V]` — 
 
 ## Prerequisites
 
-- Go 1.24+ (range-over-func requires Go 1.23+; this repo targets 1.25)
+- Go 1.25+ (range-over-func requires Go 1.23+; this repo targets 1.25)
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/lambda/README.md
+++ b/examples/lambda/README.md
@@ -16,7 +16,7 @@ Show the minimal shape of an AWS Lambda function written in Go: a handler functi
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services needed to **build** the example
 - Actually **invoking** it requires either deploying to AWS Lambda, or a local Lambda emulator (e.g. the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)); an AWS account/credentials are needed to deploy
 

--- a/examples/metric/README.md
+++ b/examples/metric/README.md
@@ -15,7 +15,7 @@ Show sending a counter metric to StatsD/Datadog via `github.com/DataDog/datadog-
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - Optional: a StatsD-compatible listener on `127.0.0.1:8125` to actually see the metrics land somewhere (this repo's `docker-compose.yml` provides one):
   ```bash
   docker compose up -d statsd

--- a/examples/mocking/README.md
+++ b/examples/mocking/README.md
@@ -18,7 +18,7 @@ Show how far plain Go interfaces go for test doubles — no framework required. 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -16,7 +16,7 @@ Show the basic `database/sql` + `go-sql-driver/mysql` pattern: connect, prepare 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - A running MySQL instance matching this repo's `docker-compose.yml` (`root`/`secret`@`localhost:3306`/`examples`):
   ```bash
   docker compose up -d mysql

--- a/examples/oop/README.md
+++ b/examples/oop/README.md
@@ -16,7 +16,7 @@ Show how Go covers the common "OOP" patterns without classes or inheritance: met
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/oop/composition/README.md
+++ b/examples/oop/composition/README.md
@@ -16,7 +16,7 @@ Show struct embedding — Go's alternative to inheritance. An embedded type's fi
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/os-exec/README.md
+++ b/examples/os-exec/README.md
@@ -18,7 +18,7 @@ Show the five things every program that shells out needs from `os/exec`: capturi
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - A Unix-like system (`echo`, `tr`, `sh`, `sleep` on `PATH` — macOS and Linux both qualify; this matches the repo's CI)
 
 ## Project Structure

--- a/examples/otel/README.md
+++ b/examples/otel/README.md
@@ -19,7 +19,7 @@ By default the spans print to stdout, so the example runs with **zero infrastruc
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - Nothing for the default run (stdout exporter)
 - For the Jaeger run: Docker Compose (`docker compose up -d jaeger` or `make infra-up` from this directory)
 - Dependencies justified: the `go.opentelemetry.io/otel` SDK and exporters are the topic being taught

--- a/examples/pool/README.md
+++ b/examples/pool/README.md
@@ -16,7 +16,7 @@ Show a small, reusable worker-pool package with per-task error tracking: run a f
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/profiling/README.md
+++ b/examples/profiling/README.md
@@ -15,7 +15,7 @@ Show the minimal way to add CPU profiling to a Go program using [`github.com/pkg
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 - To render the profile as a PDF/graph: [Graphviz](https://www.graphviz.org/download/) installed and on `PATH`
 

--- a/examples/protobuf/README.md
+++ b/examples/protobuf/README.md
@@ -16,7 +16,7 @@ Show binary serialization with Protocol Buffers: define a message schema in a `.
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required to **run** the example
 - Regenerating `addressbook.pb.go` from `addressbook.proto` requires the [protoc compiler](https://github.com/protocolbuffers/protobuf/releases) and the Go plugin (`protoc-gen-go`) on `PATH`
 

--- a/examples/recover/README.md
+++ b/examples/recover/README.md
@@ -16,7 +16,7 @@ Show `panic`/`recover`/`defer` working together: how a panic unwinds the call st
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -17,7 +17,7 @@ Show a Redis-backed task queue: an HTTP endpoint enqueues jobs and blocks waitin
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - A running Redis instance (this repo's `docker-compose.yml` provides one on `localhost:6379`):
   ```bash
   docker compose up -d redis

--- a/examples/reflection-bench/README.md
+++ b/examples/reflection-bench/README.md
@@ -16,7 +16,7 @@ Quantify the cost of `reflect`-based slice construction versus a plain `append` 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/serialization/README.md
+++ b/examples/serialization/README.md
@@ -16,7 +16,7 @@ Show a custom `UnmarshalJSON` handling a field that's sometimes a JSON object an
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/share-memory-by-communicating/README.md
+++ b/examples/share-memory-by-communicating/README.md
@@ -17,7 +17,7 @@ The classic example from the [Go Blog post of the same name](https://go.dev/blog
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - **Internet access** — polls `google.com`, `golang.org`, and `blog.golang.org` over real HTTP
 - Runs forever until interrupted; there is no built-in exit condition
 

--- a/examples/slog/README.md
+++ b/examples/slog/README.md
@@ -17,7 +17,7 @@ Show structured logging with the standard library's `log/slog` (Go 1.21+): key-v
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/sqlite/README.md
+++ b/examples/sqlite/README.md
@@ -18,7 +18,7 @@ Show the `database/sql` fundamentals — parameterized `Exec`, the `rows.Next`/`
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services, no CGo toolchain, no environment variables — the single dependency is justified because SQLite itself is the topic and `modernc.org/sqlite` is the canonical pure-Go driver
 
 ## Project Structure

--- a/examples/sync-primitives/README.md
+++ b/examples/sync-primitives/README.md
@@ -15,7 +15,7 @@ Show three `sync`/`sync/atomic` tools that solve specific coordination problems 
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/templates/README.md
+++ b/examples/templates/README.md
@@ -18,7 +18,7 @@ Show Go's two template packages and the one difference that matters between them
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/testing-patterns/README.md
+++ b/examples/testing-patterns/README.md
@@ -19,7 +19,7 @@ Show the core Go testing techniques in one place: table-driven tests, named subt
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/typecast/README.md
+++ b/examples/typecast/README.md
@@ -16,7 +16,7 @@ Benchmark four ways of calling the same operation on a value depending on how it
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required
 
 ## Project Structure

--- a/examples/wire/README.md
+++ b/examples/wire/README.md
@@ -16,7 +16,7 @@ Show compile-time dependency injection with [google/wire](https://github.com/goo
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - No external services or environment variables required to **run** the example
 - Regenerating `wire_gen.go` requires the `wire` CLI: `go install github.com/google/wire/cmd/wire@latest`
 


### PR DESCRIPTION
## Summary
- CI test matrix moves from `["1.24", "1.25"]` to `["1.25", "1.26"]`, and the tidy/lint/security jobs move from 1.25 to 1.26 — matching Go's two-release support window now that Go 1.26 is out (released 2026-02-10)
- Docs: "Requires Go 1.24+" → "Go 1.25+" in the root README, CLAUDE.md (including the CI-matrix description), and the 48 example READMEs that carried the old minimum; historical mentions of Go 1.24 as the version that *introduced* an API (`t.Context()`) stay untouched
- Module `go` directives deliberately stay at `1.25.0`: they declare the minimum supported version, and bumping them to 1.26 would expel Go 1.25 from the window

## Test plan
- [x] `GOTOOLCHAIN=go1.26.4 make ci` locally: build, vet, and `go test -race` pass across all 50 modules under Go 1.26
- [x] golangci-lint @latest (v2.12.2) rebuilt with the 1.26 toolchain: 0 issues across all modules — confirms the lint job works on 1.26 (a binary built with 1.25 cannot typecheck 1.26 and panics, which is why the job's setup-go moves to 1.26 together with the install step)
- [x] `grep` audit: no remaining "Go 1.24+" minimums anywhere
- [ ] CI green on this PR = first real run of the new matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)