### PR TITLE
Add circuit-breaker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Every example carries a **Category** and a **Difficulty** tag (Beginner / Interm
 
 | Example | Category | Description |
 |---------|----------|-------------|
+| [circuit-breaker](examples/circuit-breaker/) | Patterns & Design | Hand-rolled breaker: closed/open/half-open, fail-fast, probe quota, fake-clock tests |
 | [redis](examples/redis/) | Cloud & Infrastructure | Task queue over Redis with Gin (go-redis v9) |
 | [dynamodb](examples/dynamodb/) | Cloud & Infrastructure | DynamoDB CRUD with AWS SDK v2 |
 

--- a/examples/circuit-breaker/Makefile
+++ b/examples/circuit-breaker/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/circuit-breaker/README.md
+++ b/examples/circuit-breaker/README.md
@@ -1,0 +1,100 @@
+# Circuit Breaker
+
+**Category:** design-patterns
+**Difficulty:** Advanced
+
+## Objective
+
+Implement the circuit breaker resilience pattern from scratch — no framework — and walk its full lifecycle deterministically: **closed** (calls flow, consecutive failures are counted) → **open** (fail fast with `ErrOpen`, the downstream is left alone to recover) → **half-open** (a limited probe tests recovery; failure re-opens, enough successes close). The demo proves the protective property with a counter: 9 attempts, only 7 reach the downstream.
+
+## Concepts Covered
+
+- The three-state machine and both trip directions: `failureThreshold` consecutive failures open it, `successThreshold` successful probes close it, a failed probe re-opens it *and restarts the cooldown*
+- Failing fast as protection for **both** sides: callers stop burning latency/timeouts on a dead dependency, and the dependency stops receiving load while it recovers
+- Single-probe half-open: concurrent callers during a probe get `ErrOpen` rather than stampeding a barely-recovered service
+- Injected clock (`now func() time.Time`) — the seam that makes the state machine testable without `time.Sleep`
+- `OnStateChange` callback for observability (state transitions are exactly what you want on a dashboard)
+- Table-stakes concurrency: every decision under one mutex, race-detector clean
+
+## Prerequisites
+
+- Go 1.25+
+- No external services or environment variables required
+
+## Project Structure
+
+```
+circuit-breaker/
+├── go.mod
+├── breaker.go        # the state machine (the reusable part)
+├── main.go           # deterministic lifecycle walkthrough
+├── breaker_test.go   # fake-clock tests for every transition
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run    # lifecycle demo
+make test   # fake-clock state-machine tests
+```
+
+## Expected Output
+
+```
+--- closed: three consecutive failures trip the breaker ---
+call 1: downstream error (503 service unavailable)
+call 2: downstream error (503 service unavailable)
+  >> breaker: closed -> open
+call 3: downstream error (503 service unavailable)
+
+--- open: calls fail fast, the downstream is left alone ---
+call 4: short-circuited (circuit breaker is open)
+call 5: short-circuited (circuit breaker is open)
+downstream calls during open state: 0
+
+--- half-open probe while still broken: back to open ---
+  >> breaker: open -> half-open
+  >> breaker: half-open -> open
+call 6 (probe): downstream error (503 service unavailable)
+
+--- half-open probes after recovery: two successes close it ---
+  >> breaker: open -> half-open
+call 7 (probe): ok
+  >> breaker: half-open -> closed
+call 8 (probe): ok
+
+--- closed again: traffic flows normally ---
+call 9: ok
+final state: closed, total downstream calls: 7 (of 9 attempts)
+```
+
+## Code Walkthrough
+
+- `Breaker.Do` splits the pattern into its two halves: `allow` (may this call proceed?) and `record` (fold the outcome into the state machine). Keeping them separate makes each transition auditable — `allow` owns open→half-open (cooldown elapsed), `record` owns closed→open (failure streak), half-open→open (failed probe), and half-open→closed (probe quota met).
+- The failure counter is *consecutive*, and `record` resets it on any success while closed — a 1% error rate never trips the breaker, a hard outage trips it in `failureThreshold` calls. (Production breakers often use a rolling error-rate window instead; consecutive-failures is the simplest policy that has the right shape.)
+- Half-open admits **one probe at a time** (`probing` flag): the point of half-open is to gather a signal with minimal risk, and letting every queued caller through at once would re-create the stampede the breaker exists to prevent. A failed probe re-opens *and* resets `openedAt`, so the downstream gets a full fresh cooldown.
+- `now` is a field, not a call to `time.Now` — that one line is why `breaker_test.go` can verify cooldown behavior by advancing a `fakeClock` two minutes in zero wall time. The tests cover every edge: trip threshold, streak reset, failed-probe re-open (including the restarted cooldown), close-after-probes, and the exact transition sequence via `OnStateChange`.
+- The demo's `flakyService.calls` counter is the proof of the pattern's value: during the open window the downstream receives zero traffic, and across the whole run only 7 of 9 attempts touched it.
+
+## Common Pitfalls
+
+- **Tripping on error *rate* without a minimum volume.** 1 failure out of 1 request is a 100% error rate; naive rate-based breakers flap at low traffic. Consecutive-failure counting (used here) or rate-with-minimum-volume both avoid it.
+- **Letting all traffic through in half-open.** Half-open is a *probe*, not a reopening. Admit one (or a small quota) and short-circuit the rest, or recovery kills the dependency again.
+- **Not restarting the cooldown on a failed probe.** Otherwise the breaker probes on every call after the first cooldown, which is just the closed state with extra steps.
+- **Wrapping the breaker around code that returns business errors.** A "user not found" must not count as downstream failure or normal traffic trips the breaker. Classify errors at the call site: only transport/5xx-class failures feed `record`.
+- **One breaker for many dependencies (or one per request).** The breaker's state *is* per-downstream health; share one instance per dependency, not per call site or per request.
+- **Forgetting the fallback.** `ErrOpen` is the *start* of the story — the caller still needs a policy: cached data, a default, a queue, or a clean error to the user.
+
+## References
+
+- [Martin Fowler — CircuitBreaker](https://martinfowler.com/bliki/CircuitBreaker.html)
+- [Microsoft Azure Architecture — Circuit Breaker pattern](https://learn.microsoft.com/en-us/azure/architecture/patterns/circuit-breaker)
+- [sony/gobreaker](https://github.com/sony/gobreaker) — a production-grade implementation of the same machine
+
+## Next Steps
+
+- [http-client](../http-client/) — retries with backoff; a breaker and a retrier compose (retry *inside*, breaker *outside*)
+- [concurrency/rate-limiting](../concurrency/rate-limiting/) — the other classic protection, bounding rate instead of cutting off failure
+- [mocking](../mocking/) — the injected-dependency testing style `breaker_test.go` uses

--- a/examples/circuit-breaker/breaker.go
+++ b/examples/circuit-breaker/breaker.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ErrOpen is returned by Do when the breaker short-circuits a call: the
+// downstream is presumed unhealthy and is not contacted at all.
+var ErrOpen = errors.New("circuit breaker is open")
+
+// State is the breaker's position in its lifecycle.
+type State int
+
+const (
+	// StateClosed lets calls through and counts consecutive failures.
+	StateClosed State = iota
+	// StateOpen fails fast without calling downstream until the cooldown
+	// elapses.
+	StateOpen
+	// StateHalfOpen lets a limited number of probe calls through to test
+	// whether the downstream has recovered.
+	StateHalfOpen
+)
+
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return fmt.Sprintf("State(%d)", int(s))
+	}
+}
+
+// Breaker is a minimal consecutive-failure circuit breaker.
+//
+// Closed: calls pass through; failureThreshold consecutive failures trip it
+// to open. Open: calls fail fast with ErrOpen; after cooldown the next call
+// transitions to half-open. Half-open: up to successThreshold probes run one
+// at a time — any failure re-opens, successThreshold successes close.
+type Breaker struct {
+	failureThreshold int
+	successThreshold int
+	cooldown         time.Duration
+
+	// now is injected so tests can drive time deterministically.
+	now func() time.Time
+	// OnStateChange, if set, is called synchronously on every transition
+	// (with the breaker's lock held — it must not call back into Breaker).
+	OnStateChange func(from, to State)
+
+	mu        sync.Mutex
+	state     State
+	failures  int // consecutive failures while closed
+	successes int // successful probes while half-open
+	openedAt  time.Time
+	probing   bool // a half-open probe is in flight
+}
+
+// New returns a closed Breaker. failureThreshold consecutive failures open
+// it; after cooldown, successThreshold successful probes close it again.
+func New(failureThreshold, successThreshold int, cooldown time.Duration) *Breaker {
+	return &Breaker{
+		failureThreshold: failureThreshold,
+		successThreshold: successThreshold,
+		cooldown:         cooldown,
+		now:              time.Now,
+	}
+}
+
+// State reports the breaker's current state.
+func (b *Breaker) State() State {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.state
+}
+
+// Do runs fn under the breaker's policy. It returns ErrOpen without invoking
+// fn when the breaker is open (or a half-open probe is already in flight);
+// otherwise it returns fn's error and records the outcome.
+func (b *Breaker) Do(fn func() error) error {
+	if err := b.allow(); err != nil {
+		return err
+	}
+	err := fn()
+	b.record(err == nil)
+	return err
+}
+
+// allow decides whether a call may proceed, performing the open -> half-open
+// transition when the cooldown has elapsed.
+func (b *Breaker) allow() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case StateClosed:
+		return nil
+	case StateOpen:
+		if b.now().Sub(b.openedAt) < b.cooldown {
+			return ErrOpen
+		}
+		b.transition(StateHalfOpen)
+		b.probing = true
+		return nil
+	case StateHalfOpen:
+		// One probe at a time: concurrent callers fail fast rather than
+		// stampeding a barely-recovered downstream.
+		if b.probing {
+			return ErrOpen
+		}
+		b.probing = true
+		return nil
+	default:
+		return fmt.Errorf("unknown breaker state %v", b.state)
+	}
+}
+
+// record folds a call outcome into the state machine.
+func (b *Breaker) record(success bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case StateClosed:
+		if success {
+			b.failures = 0
+			return
+		}
+		b.failures++
+		if b.failures >= b.failureThreshold {
+			b.openedAt = b.now()
+			b.transition(StateOpen)
+		}
+	case StateHalfOpen:
+		b.probing = false
+		if !success {
+			// The downstream is still sick: re-open and restart the cooldown.
+			b.openedAt = b.now()
+			b.transition(StateOpen)
+			return
+		}
+		b.successes++
+		if b.successes >= b.successThreshold {
+			b.transition(StateClosed)
+		}
+	case StateOpen:
+		// A call that started before the trip finished after it; its outcome
+		// no longer changes the decision.
+	}
+}
+
+// transition switches states, resets counters, and fires the callback.
+// Callers must hold b.mu.
+func (b *Breaker) transition(to State) {
+	from := b.state
+	if from == to {
+		return
+	}
+	b.state = to
+	b.failures = 0
+	b.successes = 0
+	if to != StateHalfOpen {
+		b.probing = false
+	}
+	if b.OnStateChange != nil {
+		b.OnStateChange(from, to)
+	}
+}

--- a/examples/circuit-breaker/breaker_test.go
+++ b/examples/circuit-breaker/breaker_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeClock lets tests move time forward without sleeping.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+func newTestBreaker(clock *fakeClock) *Breaker {
+	b := New(3, 2, time.Minute)
+	b.now = clock.now
+	return b
+}
+
+var errBoom = errors.New("boom")
+
+func fail() error    { return errBoom }
+func succeed() error { return nil }
+
+func TestTripsAfterConsecutiveFailures(t *testing.T) {
+	t.Parallel()
+	b := newTestBreaker(&fakeClock{})
+
+	for i := 0; i < 3; i++ {
+		if err := b.Do(fail); !errors.Is(err, errBoom) {
+			t.Fatalf("call %d: err = %v, want errBoom", i+1, err)
+		}
+	}
+	if got := b.State(); got != StateOpen {
+		t.Fatalf("state after 3 failures = %v, want open", got)
+	}
+	if err := b.Do(succeed); !errors.Is(err, ErrOpen) {
+		t.Fatalf("call while open: err = %v, want ErrOpen", err)
+	}
+}
+
+func TestSuccessResetsFailureCount(t *testing.T) {
+	t.Parallel()
+	b := newTestBreaker(&fakeClock{})
+
+	_ = b.Do(fail)
+	_ = b.Do(fail)
+	_ = b.Do(succeed) // resets the consecutive-failure count
+	_ = b.Do(fail)
+	_ = b.Do(fail)
+
+	if got := b.State(); got != StateClosed {
+		t.Fatalf("state = %v, want closed — success must reset the streak", got)
+	}
+}
+
+func TestHalfOpenFailureReopens(t *testing.T) {
+	t.Parallel()
+	clock := &fakeClock{}
+	b := newTestBreaker(clock)
+
+	for i := 0; i < 3; i++ {
+		_ = b.Do(fail)
+	}
+	clock.advance(2 * time.Minute)
+
+	// Probe runs (downstream still broken) and the breaker re-opens.
+	if err := b.Do(fail); !errors.Is(err, errBoom) {
+		t.Fatalf("probe err = %v, want errBoom (probe must reach downstream)", err)
+	}
+	if got := b.State(); got != StateOpen {
+		t.Fatalf("state after failed probe = %v, want open", got)
+	}
+	// And the cooldown restarted: an immediate call is short-circuited.
+	if err := b.Do(succeed); !errors.Is(err, ErrOpen) {
+		t.Fatalf("call right after re-open: err = %v, want ErrOpen", err)
+	}
+}
+
+func TestHalfOpenSuccessesClose(t *testing.T) {
+	t.Parallel()
+	clock := &fakeClock{}
+	b := newTestBreaker(clock)
+
+	for i := 0; i < 3; i++ {
+		_ = b.Do(fail)
+	}
+	clock.advance(2 * time.Minute)
+
+	if err := b.Do(succeed); err != nil {
+		t.Fatalf("first probe: %v", err)
+	}
+	if got := b.State(); got != StateHalfOpen {
+		t.Fatalf("state after first good probe = %v, want half-open", got)
+	}
+	if err := b.Do(succeed); err != nil {
+		t.Fatalf("second probe: %v", err)
+	}
+	if got := b.State(); got != StateClosed {
+		t.Fatalf("state after two good probes = %v, want closed", got)
+	}
+}
+
+func TestStateChangesAreObserved(t *testing.T) {
+	t.Parallel()
+	clock := &fakeClock{}
+	b := newTestBreaker(clock)
+
+	var transitions []string
+	b.OnStateChange = func(from, to State) {
+		transitions = append(transitions, from.String()+"->"+to.String())
+	}
+
+	for i := 0; i < 3; i++ {
+		_ = b.Do(fail)
+	}
+	clock.advance(2 * time.Minute)
+	_ = b.Do(succeed)
+	_ = b.Do(succeed)
+
+	want := []string{"closed->open", "open->half-open", "half-open->closed"}
+	if len(transitions) != len(want) {
+		t.Fatalf("transitions = %v, want %v", transitions, want)
+	}
+	for i := range want {
+		if transitions[i] != want[i] {
+			t.Errorf("transition[%d] = %q, want %q", i, transitions[i], want[i])
+		}
+	}
+}

--- a/examples/circuit-breaker/breaker_test.go
+++ b/examples/circuit-breaker/breaker_test.go
@@ -26,7 +26,7 @@ func TestTripsAfterConsecutiveFailures(t *testing.T) {
 	t.Parallel()
 	b := newTestBreaker(&fakeClock{})
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if err := b.Do(fail); !errors.Is(err, errBoom) {
 			t.Fatalf("call %d: err = %v, want errBoom", i+1, err)
 		}
@@ -59,7 +59,7 @@ func TestHalfOpenFailureReopens(t *testing.T) {
 	clock := &fakeClock{}
 	b := newTestBreaker(clock)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_ = b.Do(fail)
 	}
 	clock.advance(2 * time.Minute)
@@ -82,7 +82,7 @@ func TestHalfOpenSuccessesClose(t *testing.T) {
 	clock := &fakeClock{}
 	b := newTestBreaker(clock)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_ = b.Do(fail)
 	}
 	clock.advance(2 * time.Minute)
@@ -111,7 +111,7 @@ func TestStateChangesAreObserved(t *testing.T) {
 		transitions = append(transitions, from.String()+"->"+to.String())
 	}
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_ = b.Do(fail)
 	}
 	clock.advance(2 * time.Minute)

--- a/examples/circuit-breaker/go.mod
+++ b/examples/circuit-breaker/go.mod
@@ -1,0 +1,3 @@
+module github.com/adnvilla/go-examples/examples/circuit-breaker
+
+go 1.25.0

--- a/examples/circuit-breaker/main.go
+++ b/examples/circuit-breaker/main.go
@@ -1,0 +1,77 @@
+// Demonstrates the circuit breaker resilience pattern: after a run of
+// consecutive failures the breaker opens and fails fast (protecting both the
+// caller's latency and the struggling downstream), then probes cautiously in
+// half-open state and only closes again once the downstream proves healthy.
+// The full closed -> open -> half-open -> open -> half-open -> closed
+// lifecycle is walked deterministically.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// flakyService simulates a downstream dependency with an on/off switch.
+type flakyService struct {
+	healthy bool
+	calls   int // how many times the breaker actually let a call through
+}
+
+var errUnavailable = errors.New("503 service unavailable")
+
+func (s *flakyService) call() error {
+	s.calls++
+	if !s.healthy {
+		return errUnavailable
+	}
+	return nil
+}
+
+func main() {
+	const cooldown = 50 * time.Millisecond
+
+	service := &flakyService{healthy: false}
+	breaker := New(3, 2, cooldown) // trip after 3 failures, close after 2 good probes
+	breaker.OnStateChange = func(from, to State) {
+		fmt.Printf("  >> breaker: %s -> %s\n", from, to)
+	}
+
+	attempt := func(label string) {
+		err := breaker.Do(service.call)
+		switch {
+		case err == nil:
+			fmt.Printf("%s: ok\n", label)
+		case errors.Is(err, ErrOpen):
+			fmt.Printf("%s: short-circuited (%v)\n", label, err)
+		default:
+			fmt.Printf("%s: downstream error (%v)\n", label, err)
+		}
+	}
+
+	fmt.Println("--- closed: three consecutive failures trip the breaker ---")
+	attempt("call 1")
+	attempt("call 2")
+	attempt("call 3")
+
+	fmt.Println("\n--- open: calls fail fast, the downstream is left alone ---")
+	before := service.calls
+	attempt("call 4")
+	attempt("call 5")
+	fmt.Printf("downstream calls during open state: %d\n", service.calls-before)
+
+	fmt.Println("\n--- half-open probe while still broken: back to open ---")
+	time.Sleep(cooldown + 10*time.Millisecond)
+	attempt("call 6 (probe)")
+
+	fmt.Println("\n--- half-open probes after recovery: two successes close it ---")
+	service.healthy = true
+	time.Sleep(cooldown + 10*time.Millisecond)
+	attempt("call 7 (probe)")
+	attempt("call 8 (probe)")
+
+	fmt.Println("\n--- closed again: traffic flows normally ---")
+	attempt("call 9")
+	fmt.Printf("final state: %s, total downstream calls: %d (of 9 attempts)\n",
+		breaker.State(), service.calls)
+}

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.25.0
 use (
 	./examples/benchmark
 	./examples/channels
+	./examples/circuit-breaker
 	./examples/concurrency/fan-out-timeout
 	./examples/concurrency/pipeline
 	./examples/concurrency/rate-limiting


### PR DESCRIPTION
## Summary
- New Advanced-tier example (first of the approved Tanda A batch): the circuit breaker pattern implemented from scratch, stdlib only
- State machine with consecutive-failure trip, fail-fast open state, cooldown, and single-probe half-open (concurrent callers during a probe short-circuit instead of stampeding); failed probes re-open **and restart the cooldown**
- Deterministic demo walks closed → open → half-open → open → half-open → closed and proves the protective property with a counter: 9 attempts, only 7 reach the downstream (0 during the open window)
- Injected clock (`now` field) makes the machine testable without sleeps; 5 fake-clock tests cover trip threshold, streak reset on success, failed-probe re-open with fresh cooldown, close-after-probes, and the exact transition sequence via `OnStateChange`
- README pitfalls: rate-without-volume flapping, half-open stampedes, business errors tripping the breaker, per-dependency (not per-request) instances, and the missing-fallback trap

## Test plan
- [x] `make run EXAMPLE=circuit-breaker` — output matches the README exactly
- [x] `make test EXAMPLE=circuit-breaker` — 5 tests pass with `-race`
- [x] `make check EXAMPLE=circuit-breaker` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)