### PR TITLE
Add Editing files guidance to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,16 @@ against the permission allowlist independently.
   (append `EXAMPLE=<name>` to scope to one example). The Makefile
   encapsulates any needed `cd` inside its recipes, so you never chain.
 
+### Editing files
+
+- Use the built-in Edit tool to modify source files, NOT shell commands
+  like `sed -i`, `awk`, or `perl -i`. The Edit tool shows a reviewable
+  diff, respects the permission mode, and won't silently corrupt code on
+  a mismatched pattern.
+- Reserve `sed`/`awk` for read-only text transformations piped to stdout
+  (e.g. inspecting or filtering output), never for in-place file edits
+  (`-i`) on code.
+
 ### Validating an example (canonical flow)
 New example → `make use EXAMPLE=<name>` (once), then
 `make check EXAMPLE=<name>`.


### PR DESCRIPTION
## Summary
- Adds an "Editing files" section to CLAUDE.md: agents must use the built-in Edit tool for file modifications instead of in-place shell edits (`sed -i`/`awk`/`perl -i`) — reviewable diffs, permission-mode aware, no silent corruption on mismatched patterns
- `sed`/`awk` remain fine for read-only transformations piped to stdout
- Docs-only change, authored in the working tree by the repo owner; committed as-is

## Test plan
- [x] Docs-only — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)