### PR TITLE
Add websocket example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Every example carries a **Category** and a **Difficulty** tag (Beginner / Interm
 |---------|----------|-------------|
 | [circuit-breaker](examples/circuit-breaker/) | Patterns & Design | Hand-rolled breaker: closed/open/half-open, fail-fast, probe quota, fake-clock tests |
 | [grpc-advanced](examples/grpc-advanced/) | HTTP | Interceptors (auth via metadata), bidirectional streaming, deadline propagation |
+| [websocket](examples/websocket/) | HTTP | Broadcast hub over WebSockets: reader pumps, ping liveness, slow-consumer policy |
 | [distributed-lock](examples/distributed-lock/) | Cloud & Infrastructure | Redis lock: `SET NX PX`, owner-only release (Lua), lease renewal, fencing tokens |
 | [postgres](examples/postgres/) | Cloud & Infrastructure | pgx: write skew live under read committed vs serializable (40001 + retry), LISTEN/NOTIFY |
 | [kafka](examples/kafka/) | Messaging | Keyed producer (key→partition), consumer group at-least-once, offset resume on restart |

--- a/examples/websocket/Makefile
+++ b/examples/websocket/Makefile
@@ -1,0 +1,24 @@
+## run: run the example
+.PHONY: run
+run:
+	go run .
+
+## test: run tests with the race detector
+.PHONY: test
+test:
+	go test -race -count=1 ./...
+
+## vet: run go vet
+.PHONY: vet
+vet:
+	go vet ./...
+
+## lint: run golangci-lint (requires golangci-lint in PATH)
+.PHONY: lint
+lint:
+	golangci-lint run ./...
+
+## fmt: check gofmt formatting
+.PHONY: fmt
+fmt:
+	@test -z "$$(gofmt -l .)" || (echo "not gofmt'd:"; gofmt -l .; exit 1)

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -1,0 +1,88 @@
+# WebSocket
+
+**Category:** networking
+**Difficulty:** Advanced
+
+## Objective
+
+Build the canonical WebSocket architecture — an HTTP endpoint that upgrades connections into a **broadcast hub** — with `coder/websocket`, and get the lifecycle details right: per-client reader goroutines (control frames like pongs are only processed while a `Read` is in flight, a real gotcha discovered live while building this), ping for liveness, read limits, per-write deadlines so one slow client can't wedge the room, and clean closes with status codes. Server and two clients run in one process; `go run .` shows the full chat round trip and terminates on its own.
+
+## Concepts Covered
+
+- `websocket.Accept` in a plain `http.Handler` — the upgrade is just HTTP, so the hub mounts on any mux or server
+- The hub shape: register/unregister under a mutex, fan-out `broadcast` with a **per-write timeout** (the slow-consumer policy made explicit)
+- The client reader pump: a goroutine that `Read`s continuously into a channel — not an optimization, but the requirement for pings, pongs, and close frames to be processed at all
+- `Ping(ctx)` as real liveness (an open TCP connection says nothing about the peer)
+- `SetReadLimit` bounding what one frame can cost; `Close(StatusNormalClosure, ...)` vs `CloseNow`
+- Graceful teardown ordering: clients close → hub unregisters → `http.Server.Shutdown`
+
+## Prerequisites
+
+- Go 1.25+
+- No external services or environment variables required — `coder/websocket` (the maintained successor of `nhooyr.io/websocket`) is the canonical minimal WebSocket library and the topic being taught
+
+## Project Structure
+
+```
+websocket/
+├── go.mod
+├── hub.go        # Hub: accept, register, read loop, broadcast (the reusable part)
+├── main.go       # server + two clients: ping, broadcasts, clean close
+├── hub_test.go   # broadcast fan-out and unregister-on-close over httptest
+├── Makefile
+└── README.md
+```
+
+## How to Run
+
+```bash
+make run
+make test
+```
+
+## Expected Output
+
+```
+--- hub up; two clients connect ---
+hub reports 2 connected clients
+alice: ping round trip ok
+
+--- broadcast: every message reaches every client ---
+alice received: "alice: hola"
+bob received: "alice: hola"
+alice received: "bob: qué tal"
+bob received: "bob: qué tal"
+
+--- clean close: status codes end the conversation ---
+hub reports 0 connected clients after closes
+server: stopped cleanly
+```
+
+## Code Walkthrough
+
+- `Hub.ServeHTTP` is an ordinary `http.Handler`: `websocket.Accept` performs the upgrade (and writes the HTTP error itself if it fails), then the handler *is* the connection's read loop — register, read-and-broadcast until error, unregister via `defer`. One goroutine per connection, lifecycle tied to the handler, nothing leaked.
+- `broadcast` snapshots the client list under the mutex, then writes outside it with a 2-second deadline per client. That deadline is the **slow-consumer policy**: a wedged client loses messages instead of blocking the room. Real systems choose between dropping (here), buffering per client, or disconnecting laggards — but they must choose; the default (block everyone) is the worst option.
+- `client`/`connect` on the demo side runs the **reader pump**: a goroutine that `Read`s continuously and forwards data frames into a channel. This is the detail that bit during development: `Ping` timed out until the pump existed, because pongs (like all control frames) are only processed *inside* a `Read` call. A client that reads "when it expects something" has a connection that is only alive when it expects something.
+- `alice.conn.Ping(ctx)` completes only because both sides are reading — the server's loop processes the ping and replies; alice's pump processes the pong. That's the liveness check to run on idle connections, on a timer, in production.
+- Teardown is ordered and verified: `Close(StatusNormalClosure)` performs the close handshake, the hub's counts drain to zero (asserted, not assumed), then `server.Shutdown` ends the HTTP side.
+
+## Common Pitfalls
+
+- **Reading only when you expect data.** Control frames (ping/pong/close) are processed during `Read`; without a continuous reader, pings time out and closes go unnoticed. Every long-lived client needs a read pump — this example's original draft didn't, and its `Ping` deadlocked.
+- **Broadcasting while holding the lock, with no write deadline.** One slow client backpressures the entire hub. Snapshot the list, write with deadlines, and pick an explicit slow-consumer policy.
+- **No `SetReadLimit`.** The default protects you (32 KiB in this library), but know the number: a malicious client sending a giant frame is an allocation attack.
+- **Confusing `Close` and `CloseNow`.** `Close` performs the status-code handshake (use it on the happy path); `CloseNow` tears down the TCP connection (use it in `defer` as the failsafe).
+- **Treating an open connection as a live user.** NAT boxes and phones drop silently; only ping round trips (or application heartbeats) distinguish "connected" from "gone".
+- **Skipping `OriginPatterns` in real browsers-facing servers.** `Accept` enforces same-origin by default; configure it consciously rather than disabling verification to "make it work".
+
+## References
+
+- [coder/websocket documentation](https://pkg.go.dev/github.com/coder/websocket)
+- [RFC 6455 — The WebSocket Protocol](https://datatracker.ietf.org/doc/html/rfc6455)
+- [MDN — WebSockets API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
+
+## Next Steps
+
+- [http-server](../http-server/) — the plain-HTTP server machinery the upgrade endpoint mounts on
+- [concurrency/pipeline](../concurrency/pipeline/) — the channel patterns behind per-client send buffers
+- [graceful-shutdown-signals](../graceful-shutdown-signals/) — wiring the teardown ordering to SIGTERM

--- a/examples/websocket/go.mod
+++ b/examples/websocket/go.mod
@@ -1,0 +1,5 @@
+module github.com/adnvilla/go-examples/examples/websocket
+
+go 1.25.0
+
+require github.com/coder/websocket v1.8.15

--- a/examples/websocket/go.sum
+++ b/examples/websocket/go.sum
@@ -1,0 +1,2 @@
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=

--- a/examples/websocket/hub.go
+++ b/examples/websocket/hub.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// Hub is a broadcast fan-out: every message received from any client is
+// written to all connected clients. This is the core of chat rooms, live
+// dashboards, and collaborative editors.
+type Hub struct {
+	mu      sync.Mutex
+	clients map[*websocket.Conn]bool
+}
+
+// NewHub returns an empty hub.
+func NewHub() *Hub {
+	return &Hub{clients: make(map[*websocket.Conn]bool)}
+}
+
+// ClientCount reports how many connections are currently registered.
+func (h *Hub) ClientCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients)
+}
+
+func (h *Hub) register(conn *websocket.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.clients[conn] = true
+}
+
+func (h *Hub) unregister(conn *websocket.Conn) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.clients, conn)
+}
+
+// broadcast writes msg to every registered client. Each write gets its own
+// short deadline so one stuck client can't wedge the whole room — the
+// slow-consumer problem every broadcast system has to answer.
+func (h *Hub) broadcast(msg []byte) {
+	h.mu.Lock()
+	conns := make([]*websocket.Conn, 0, len(h.clients))
+	for c := range h.clients {
+		conns = append(conns, c)
+	}
+	h.mu.Unlock()
+
+	for _, conn := range conns {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		// A failed write means the client is gone or hopelessly slow; the
+		// read loop will notice and unregister it. Dropping the message for
+		// that client is the deliberate policy here.
+		_ = conn.Write(ctx, websocket.MessageText, msg)
+		cancel()
+	}
+}
+
+// ServeHTTP upgrades the request to a WebSocket and runs the read loop:
+// register, then read messages and broadcast each one until the client
+// closes or errors, then unregister.
+func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		// Accept has already written the HTTP error response.
+		return
+	}
+	defer conn.CloseNow() //nolint:errcheck
+
+	conn.SetReadLimit(1 << 20) // 1 MiB: bound what a single frame can cost
+	h.register(conn)
+	defer h.unregister(conn)
+
+	for {
+		_, data, err := conn.Read(r.Context())
+		if err != nil {
+			// Normal closure and network errors end the loop the same way;
+			// websocket.CloseStatus(err) distinguishes them when needed.
+			return
+		}
+		h.broadcast(data)
+	}
+}
+
+// dial connects a client to the hub's ws:// URL.
+func dial(ctx context.Context, url string) (*websocket.Conn, error) {
+	conn, _, err := websocket.Dial(ctx, url, nil) //nolint:bodyclose // coder/websocket: resp.Body never needs closing
+	if err != nil {
+		return nil, fmt.Errorf("dialing %s: %w", url, err)
+	}
+	return conn, nil
+}

--- a/examples/websocket/hub_test.go
+++ b/examples/websocket/hub_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// startHub serves the hub on an httptest server and returns its ws:// URL.
+func startHub(t *testing.T) (*Hub, string) {
+	t.Helper()
+	hub := NewHub()
+	ts := httptest.NewServer(hub)
+	t.Cleanup(ts.Close)
+	return hub, "ws" + strings.TrimPrefix(ts.URL, "http")
+}
+
+func TestBroadcastReachesAllClients(t *testing.T) {
+	t.Parallel()
+	hub, url := startHub(t)
+
+	a, err := dial(t.Context(), url)
+	if err != nil {
+		t.Fatalf("dialing a: %v", err)
+	}
+	defer a.CloseNow() //nolint:errcheck
+	b, err := dial(t.Context(), url)
+	if err != nil {
+		t.Fatalf("dialing b: %v", err)
+	}
+	defer b.CloseNow() //nolint:errcheck
+	waitCount(t, hub, 2)
+
+	if err := a.Write(t.Context(), websocket.MessageText, []byte("ping-all")); err != nil {
+		t.Fatalf("writing: %v", err)
+	}
+	for name, conn := range map[string]*websocket.Conn{"a": a, "b": b} {
+		_, data, err := conn.Read(t.Context())
+		if err != nil {
+			t.Fatalf("%s reading: %v", name, err)
+		}
+		if got := string(data); got != "ping-all" {
+			t.Errorf("%s received %q, want %q", name, got, "ping-all")
+		}
+	}
+}
+
+func TestCloseUnregistersClient(t *testing.T) {
+	t.Parallel()
+	hub, url := startHub(t)
+
+	conn, err := dial(t.Context(), url)
+	if err != nil {
+		t.Fatalf("dialing: %v", err)
+	}
+	waitCount(t, hub, 1)
+
+	if err := conn.Close(websocket.StatusNormalClosure, "bye"); err != nil {
+		t.Fatalf("closing: %v", err)
+	}
+	waitCount(t, hub, 0)
+}
+
+// waitCount polls until the hub registers exactly n clients; registration and
+// unregistration happen in handler goroutines.
+func waitCount(t *testing.T, hub *Hub, n int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for hub.ClientCount() != n {
+		if time.Now().After(deadline) {
+			t.Fatalf("hub has %d clients, want %d", hub.ClientCount(), n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -1,0 +1,172 @@
+// Demonstrates WebSockets in Go with coder/websocket: an HTTP endpoint that
+// upgrades connections, a hub that broadcasts every message to all clients,
+// per-client reader goroutines (the shape real clients need — control frames
+// like pongs are only processed while a Read is in flight), ping for
+// liveness, and clean closes with status codes. Server and two clients run
+// in one process, so `go run .` shows a full chat round trip and terminates
+// on its own.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// client pairs a connection with a continuously running reader goroutine.
+// The pump is not an optimization: pings, pongs, and close frames are only
+// processed while a Read is in flight, so a client that reads sporadically
+// has a connection that is only sporadically alive.
+type client struct {
+	name string
+	conn *websocket.Conn
+	msgs chan string
+}
+
+func connect(ctx context.Context, name, url string) (*client, error) {
+	conn, _, err := websocket.Dial(ctx, url, nil) //nolint:bodyclose // coder/websocket: resp.Body never needs closing
+	if err != nil {
+		return nil, fmt.Errorf("dialing %s: %w", url, err)
+	}
+	c := &client{name: name, conn: conn, msgs: make(chan string, 8)}
+	go func() {
+		defer close(c.msgs)
+		for {
+			_, data, err := conn.Read(ctx)
+			if err != nil {
+				return // normal closure and errors both end the pump
+			}
+			c.msgs <- string(data)
+		}
+	}()
+	return c, nil
+}
+
+// recv waits for the next broadcast to arrive at this client.
+func (c *client) recv(ctx context.Context) (string, error) {
+	select {
+	case msg, ok := <-c.msgs:
+		if !ok {
+			return "", fmt.Errorf("%s: connection closed", c.name)
+		}
+		return msg, nil
+	case <-ctx.Done():
+		return "", fmt.Errorf("%s waiting for broadcast: %w", c.name, ctx.Err())
+	}
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Real HTTP server on a random loopback port; the hub is its handler.
+	hub := NewHub()
+	var lc net.ListenConfig
+	lis, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("listening: %w", err)
+	}
+	server := &http.Server{Handler: hub, ReadHeaderTimeout: 5 * time.Second}
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(lis) }()
+	url := "ws://" + lis.Addr().String()
+	fmt.Println("--- hub up; two clients connect ---")
+
+	alice, err := connect(ctx, "alice", url)
+	if err != nil {
+		return err
+	}
+	defer alice.conn.CloseNow() //nolint:errcheck
+	bob, err := connect(ctx, "bob", url)
+	if err != nil {
+		return err
+	}
+	defer bob.conn.CloseNow() //nolint:errcheck
+
+	// Registration happens in the server's handler goroutines; wait until
+	// the hub has seen both connections before broadcasting.
+	if err := waitForClients(ctx, hub, 2); err != nil {
+		return err
+	}
+	fmt.Printf("hub reports %d connected clients\n", hub.ClientCount())
+
+	// Liveness: a ping round trip proves the peer is really there — TCP
+	// being open says nothing. It works here precisely because alice's
+	// reader pump is processing frames continuously.
+	if err := alice.conn.Ping(ctx); err != nil {
+		return fmt.Errorf("pinging: %w", err)
+	}
+	fmt.Println("alice: ping round trip ok")
+
+	fmt.Println("\n--- broadcast: every message reaches every client ---")
+	for _, msg := range []struct {
+		sender *client
+		text   string
+	}{
+		{alice, "alice: hola"},
+		{bob, "bob: qué tal"},
+	} {
+		if err := msg.sender.conn.Write(ctx, websocket.MessageText, []byte(msg.text)); err != nil {
+			return fmt.Errorf("%s sending: %w", msg.sender.name, err)
+		}
+		for _, receiver := range []*client{alice, bob} {
+			got, err := receiver.recv(ctx)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("%s received: %q\n", receiver.name, got)
+		}
+	}
+
+	fmt.Println("\n--- clean close: status codes end the conversation ---")
+	if err := alice.conn.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		return fmt.Errorf("closing alice: %w", err)
+	}
+	if err := bob.conn.Close(websocket.StatusNormalClosure, "done"); err != nil {
+		return fmt.Errorf("closing bob: %w", err)
+	}
+	if err := waitForClients(ctx, hub, 0); err != nil {
+		return err
+	}
+	fmt.Printf("hub reports %d connected clients after closes\n", hub.ClientCount())
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelShutdown()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shutting down server: %w", err)
+	}
+	if err := <-serveErr; !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("serving: %w", err)
+	}
+	fmt.Println("server: stopped cleanly")
+	return nil
+}
+
+// waitForClients polls the hub until it has registered exactly n clients —
+// registration runs in handler goroutines, so it's eventually consistent
+// with the dials.
+func waitForClients(ctx context.Context, hub *Hub, n int) error {
+	for {
+		if hub.ClientCount() == n {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for %d clients: %w", n, ctx.Err())
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/go.work
+++ b/go.work
@@ -57,5 +57,6 @@ use (
 	./examples/testcontainers
 	./examples/testing-patterns
 	./examples/typecast
+	./examples/websocket
 	./examples/wire
 )


### PR DESCRIPTION
## Summary
- New Advanced-tier example (second of Tanda B): WebSockets with `coder/websocket` — an `http.Handler` hub that upgrades connections and broadcasts every message to all clients
- Gets the lifecycle details right, including one discovered live while building it: **control frames (pong/close) are only processed while a `Read` is in flight** — the demo's original `Ping` deadlocked until per-client reader pumps existed; documented as the lead pitfall
- Slow-consumer policy made explicit: broadcast writes carry a 2s per-client deadline (drop, don't block the room); `SetReadLimit` bounds frame cost; `Close(StatusNormalClosure)` vs `CloseNow` distinction shown
- Ordered, verified teardown: status-code closes → hub count drains to zero (asserted) → `http.Server.Shutdown`
- Server + two clients in one process — deterministic, self-terminating `go run .`; tests cover broadcast fan-out and unregister-on-close over httptest
- Dependency justified: `coder/websocket` (successor of `nhooyr.io/websocket`) is the canonical minimal library and the topic

## Test plan
- [x] `make run EXAMPLE=websocket` — output matches the README exactly
- [x] `make test EXAMPLE=websocket` — 2 tests pass with `-race`
- [x] `make check EXAMPLE=websocket` — 0 issues (bodyclose nolint justified: the library documents resp.Body never needs closing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)